### PR TITLE
Fix bug in gitlab run images

### DIFF
--- a/.gitlab-ci/docker-ros.yml
+++ b/.gitlab-ci/docker-ros.yml
@@ -97,19 +97,23 @@ default:
 .build:
   script:
     - |-
-      if [[ ${CI_RUNNER_EXECUTABLE_ARCH} != ${_PLATFORM} && ${CI_RUNNER_EXECUTABLE_ARCH} != linux/${_PLATFORM} ]]; then
-        docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+      if [[ "${PLATFORM}" =~ ${_PLATFORM} ]]; then
+        if [[ ${CI_RUNNER_EXECUTABLE_ARCH} != ${_PLATFORM} && ${CI_RUNNER_EXECUTABLE_ARCH} != linux/${_PLATFORM} ]]; then
+          docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+        fi
+        TARGET=${_TARGET} PLATFORM=${_PLATFORM} ./docker/docker-ros/scripts/ci.sh
+        echo -e "section_start:`date +%s`:push_section[collapsed=true]\r\e[0K[docker-ros] Push ${IMAGE}"
+        docker push ${IMAGE}
+        echo -e "section_end:`date +%s`:push_section\r\e[0K"
+      else
+        echo "Do not build image for ${_PLATFORM}!"
       fi
-    - TARGET=${_TARGET} PLATFORM=${_PLATFORM} ./docker/docker-ros/scripts/ci.sh
-    - echo -e "section_start:`date +%s`:push_section[collapsed=true]\r\e[0K[docker-ros] Push ${IMAGE}"
-    - docker push ${IMAGE}
-    - echo -e "section_end:`date +%s`:push_section\r\e[0K"
 
 dev-amd64:
   stage: Build dev Images
   extends: .build
   rules:
-    - if: $PLATFORM =~ /.*amd64.*/ && $TARGET =~ /.*dev.*/
+    - if: $TARGET =~ /.*dev.*/
   variables:
     _PLATFORM: amd64
     _TARGET: dev
@@ -122,7 +126,7 @@ dev-arm64:
   extends: .build
   tags: [privileged, arm64]
   rules:
-    - if: $PLATFORM =~ /.*arm64.*/ && $TARGET =~ /.*dev.*/
+    - if: $TARGET =~ /.*dev.*/
   variables:
     _PLATFORM: arm64
     _TARGET: dev
@@ -137,7 +141,7 @@ run-amd64:
     - job: dev-amd64
       optional: true
   rules:
-    - if: $PLATFORM =~ /.*amd64.*/ && $TARGET =~ /.*run.*/
+    - if: $TARGET =~ /.*run.*/
   variables:
     _PLATFORM: amd64
     _TARGET: run
@@ -153,7 +157,7 @@ run-arm64:
     - job: dev-arm64
       optional: true
   rules:
-    - if: $PLATFORM =~ /.*arm64.*/ && $TARGET =~ /.*run.*/
+    - if: $TARGET =~ /.*run.*/
   variables:
     _PLATFORM: arm64
     _TARGET: run
@@ -224,6 +228,8 @@ Test dev-arm64:
     - if: $PLATFORM == '' || $TARGET == ''
       when: never
   script:
+    - echo $PLATFORM
+    - echo $CI_RUNNER_EXECUTABLE_ARCH
     - |-
       if [[ "${PLATFORM}" =~ amd64 && "${PLATFORM}" =~ arm64 ]]; then
         [[ "${TARGET}" =~ dev ]] && docker manifest create ${IMG_DEV} --amend ${_IMAGE_DEV_CI_AMD64} --amend ${_IMAGE_DEV_CI_ARM64}

--- a/.gitlab-ci/docker-ros.yml
+++ b/.gitlab-ci/docker-ros.yml
@@ -21,7 +21,7 @@ variables:
   REGISTRY:                   ${CI_REGISTRY}                          # Docker registry to push images to
   REGISTRY_USER:              ${CI_REGISTRY_USER}                     # Docker registry username
   REGISTRY_PASSWORD:          ${CI_REGISTRY_PASSWORD}                 # Docker registry password
-  ENABLE_INDUSTRIAL_CI:       'true'                                 # Enable industrial_ci
+  ENABLE_INDUSTRIAL_CI:       'false'                                 # Enable industrial_ci
   ENABLE_SINGLEARCH_PUSH:     'false'                                 # Enable push of single arch images with [-amd64|-arm64] postfix
   ENABLE_PUSH_AS_LATEST:      'false'                                 # Push images with tag `latest`/`latest-dev` in addition to the configured image names
   ROS_DISTRO:                 ''                                      # ROS Distro (required if ROS is not installed in `base-image`)

--- a/.gitlab-ci/docker-ros.yml
+++ b/.gitlab-ci/docker-ros.yml
@@ -226,8 +226,6 @@ Test dev-arm64:
     - if: $PLATFORM == '' || $TARGET == ''
       when: never
   script:
-    - echo $PLATFORM
-    - echo $CI_RUNNER_EXECUTABLE_ARCH
     - |-
       if [[ "${PLATFORM}" =~ amd64 && "${PLATFORM}" =~ arm64 ]]; then
         [[ "${TARGET}" =~ dev ]] && docker manifest create ${IMG_DEV} --amend ${_IMAGE_DEV_CI_AMD64} --amend ${_IMAGE_DEV_CI_ARM64}

--- a/.gitlab-ci/docker-ros.yml
+++ b/.gitlab-ci/docker-ros.yml
@@ -77,6 +77,7 @@ default:
     - privileged
     - amd64
   before_script:
+    - if [[ ${_PLATFORM} ]]  && ! [[ "${PLATFORM}" =~ ${_PLATFORM} ]]; then echo "job will not run for this architecture (${_PLATFORM})" && exit 0; fi
     - echo -e "section_start:`date +%s`:setup_section[collapsed=true]\r\e[0K[docker-ros] Setup docker-ros"
     - apk add bash
     - cd ${BUILD_CONTEXT}
@@ -97,17 +98,13 @@ default:
 .build:
   script:
     - |-
-      if [[ "${PLATFORM}" =~ ${_PLATFORM} ]]; then
-        if [[ ${CI_RUNNER_EXECUTABLE_ARCH} != ${_PLATFORM} && ${CI_RUNNER_EXECUTABLE_ARCH} != linux/${_PLATFORM} ]]; then
-          docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
-        fi
-        TARGET=${_TARGET} PLATFORM=${_PLATFORM} ./docker/docker-ros/scripts/ci.sh
-        echo -e "section_start:`date +%s`:push_section[collapsed=true]\r\e[0K[docker-ros] Push ${IMAGE}"
-        docker push ${IMAGE}
-        echo -e "section_end:`date +%s`:push_section\r\e[0K"
-      else
-        echo "Do not build image for ${_PLATFORM}!"
+      if [[ ${CI_RUNNER_EXECUTABLE_ARCH} != ${_PLATFORM} && ${CI_RUNNER_EXECUTABLE_ARCH} != linux/${_PLATFORM} ]]; then
+        docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
       fi
+      TARGET=${_TARGET} PLATFORM=${_PLATFORM} ./docker/docker-ros/scripts/ci.sh
+      echo -e "section_start:`date +%s`:push_section[collapsed=true]\r\e[0K[docker-ros] Push ${IMAGE}"
+      docker push ${IMAGE}
+      echo -e "section_end:`date +%s`:push_section\r\e[0K"
 
 dev-amd64:
   stage: Build dev Images
@@ -174,6 +171,7 @@ run-arm64:
     AFTER_INIT_EMBED: git config --global url.https://${GIT_HTTPS_USER}:${GIT_HTTPS_PASSWORD}@${GIT_HTTPS_SERVER}.insteadOf https://${GIT_HTTPS_SERVER}
     DOCKER_RUN_OPTS: -u root:root
   before_script:
+    - if [[ ${_PLATFORM} ]]  && ! [[ "${PLATFORM}" =~ ${_PLATFORM} ]]; then echo "job will not run for this architecture (${_PLATFORM})" && exit 0; fi
     - docker login -u ${REGISTRY_USER} -p ${REGISTRY_PASSWORD} ${REGISTRY}
     - apk add --update bash coreutils grep tar
     - |-
@@ -191,7 +189,7 @@ Test dev-amd64:
     - job: dev-amd64
       optional: true
   rules:
-    - if: $ENABLE_INDUSTRIAL_CI == 'true' && $PLATFORM =~ /.*amd64.*/
+    - if: $ENABLE_INDUSTRIAL_CI == 'true'
   variables:
     DOCKER_IMAGE: ${_IMAGE_DEV_CI_AMD64}
     _PLATFORM: amd64
@@ -204,7 +202,7 @@ Test dev-arm64:
     - job: dev-arm64
       optional: true
   rules:
-      - if: $ENABLE_INDUSTRIAL_CI == 'true' && $PLATFORM =~ /.*arm64.*/
+      - if: $ENABLE_INDUSTRIAL_CI == 'true'
   variables:
     DOCKER_IMAGE: ${_IMAGE_DEV_CI_ARM64}
     _PLATFORM: arm64

--- a/.gitlab-ci/docker-ros.yml
+++ b/.gitlab-ci/docker-ros.yml
@@ -77,7 +77,7 @@ default:
     - privileged
     - amd64
   before_script:
-    - if [[ ${_PLATFORM} ]]  && ! [[ "${PLATFORM}" =~ ${_PLATFORM} ]]; then echo "job will not run for this architecture (${_PLATFORM})" && exit 0; fi
+    - if [[ -n ${_PLATFORM} ]]  && ! [[ "${PLATFORM}" =~ ${_PLATFORM} ]]; then echo "Platform '${_PLATFORM}' is skipped; can be enabled by adding '${_PLATFORM}' to the 'PLATFORM' variable" && exit 0; fi
     - echo -e "section_start:`date +%s`:setup_section[collapsed=true]\r\e[0K[docker-ros] Setup docker-ros"
     - apk add bash
     - cd ${BUILD_CONTEXT}
@@ -171,7 +171,7 @@ run-arm64:
     AFTER_INIT_EMBED: git config --global url.https://${GIT_HTTPS_USER}:${GIT_HTTPS_PASSWORD}@${GIT_HTTPS_SERVER}.insteadOf https://${GIT_HTTPS_SERVER}
     DOCKER_RUN_OPTS: -u root:root
   before_script:
-    - if [[ ${_PLATFORM} ]]  && ! [[ "${PLATFORM}" =~ ${_PLATFORM} ]]; then echo "job will not run for this architecture (${_PLATFORM})" && exit 0; fi
+    - if [[ -n ${_PLATFORM} ]]  && ! [[ "${PLATFORM}" =~ ${_PLATFORM} ]]; then echo "Platform '${_PLATFORM}' is skipped; can be enabled by adding '${_PLATFORM}' to the 'PLATFORM' variable" && exit 0; fi
     - docker login -u ${REGISTRY_USER} -p ${REGISTRY_PASSWORD} ${REGISTRY}
     - apk add --update bash coreutils grep tar
     - |-

--- a/.gitlab-ci/docker-ros.yml
+++ b/.gitlab-ci/docker-ros.yml
@@ -21,7 +21,7 @@ variables:
   REGISTRY:                   ${CI_REGISTRY}                          # Docker registry to push images to
   REGISTRY_USER:              ${CI_REGISTRY_USER}                     # Docker registry username
   REGISTRY_PASSWORD:          ${CI_REGISTRY_PASSWORD}                 # Docker registry password
-  ENABLE_INDUSTRIAL_CI:       'false'                                 # Enable industrial_ci
+  ENABLE_INDUSTRIAL_CI:       'true'                                 # Enable industrial_ci
   ENABLE_SINGLEARCH_PUSH:     'false'                                 # Enable push of single arch images with [-amd64|-arm64] postfix
   ENABLE_PUSH_AS_LATEST:      'false'                                 # Push images with tag `latest`/`latest-dev` in addition to the configured image names
   ROS_DISTRO:                 ''                                      # ROS Distro (required if ROS is not installed in `base-image`)
@@ -228,10 +228,10 @@ Test dev-arm64:
       if [[ "${PLATFORM}" =~ amd64 && "${PLATFORM}" =~ arm64 ]]; then
         [[ "${TARGET}" =~ dev ]] && docker manifest create ${IMG_DEV} --amend ${_IMAGE_DEV_CI_AMD64} --amend ${_IMAGE_DEV_CI_ARM64}
         [[ "${TARGET}" =~ run ]] && docker manifest create ${IMG_RUN} --amend ${_IMAGE_RUN_CI_AMD64} --amend ${_IMAGE_RUN_CI_ARM64}
-      elif [[ "${PLATFORM}" == amd64 ]]; then
+      elif [[ "${PLATFORM}" =~ amd64 ]]; then
         [[ "${TARGET}" =~ dev ]] && docker manifest create ${IMG_DEV} --amend ${_IMAGE_DEV_CI_AMD64}
         [[ "${TARGET}" =~ run ]] && docker manifest create ${IMG_RUN} --amend ${_IMAGE_RUN_CI_AMD64}
-      elif [[ "${PLATFORM}" == arm64 ]]; then
+      elif [[ "${PLATFORM}" =~ arm64 ]]; then
         [[ "${TARGET}" =~ dev ]] && docker manifest create ${IMG_DEV} --amend ${_IMAGE_DEV_CI_ARM64}
         [[ "${TARGET}" =~ run ]] && docker manifest create ${IMG_RUN} --amend ${_IMAGE_RUN_CI_ARM64}
       fi

--- a/.gitlab-ci/docker-ros.yml
+++ b/.gitlab-ci/docker-ros.yml
@@ -141,7 +141,6 @@ run-amd64:
   variables:
     _PLATFORM: amd64
     _TARGET: run
-    COMMAND: ${COMMAND}
     IMAGE: ${_IMAGE_RUN_CI_AMD64}
     ENABLE_SINGLEARCH_PUSH: 'true'
     _IMAGE_POSTFIX: _${CI_COMMIT_REF_SLUG}_ci
@@ -158,7 +157,6 @@ run-arm64:
   variables:
     _PLATFORM: arm64
     _TARGET: run
-    COMMAND: ${COMMAND}
     IMAGE: ${_IMAGE_RUN_CI_ARM64}
     ENABLE_SINGLEARCH_PUSH: 'true'
     _IMAGE_POSTFIX: _${CI_COMMIT_REF_SLUG}_ci

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -18,11 +18,11 @@ if [[ $DOCKER_UID && $DOCKER_GID ]]; then
             --password "$(openssl passwd -1 $DOCKER_USER)" \
             $DOCKER_USER && \
             touch /home/$DOCKER_USER/.sudo_as_admin_successful
-    chown -R $DOCKER_USER:$DOCKER_USER $WORKSPACE
-    ln -s $WORKSPACE /home/$DOCKER_USER/ws
-    cd /home/$DOCKER_USER/ws
     cp /root/.bashrc /home/$DOCKER_USER
-    chown $DOCKER_USER:$DOCKER_USER /home/$DOCKER_USER/.bashrc
+    ln -s $WORKSPACE /home/$DOCKER_USER/ws
+    chown -R $DOCKER_USER:$DOCKER_USER $WORKSPACE
+    chown -R $DOCKER_USER:$DOCKER_USER /home/$DOCKER_USER
+    [[ $(pwd) == "$WORKSPACE" ]] && cd /home/$DOCKER_USER/ws
     exec gosu $DOCKER_USER "$@"
 else
     exec "$@"


### PR DESCRIPTION
- fix default command for run images, build with gitlab ci
- fix handling of `${CI_RUNNER_EXECUTABLE_ARCH}` (default runner architecure) by checking the platform variable in job:script instead of job:rule
- improve entrypoint analogous to https://github.com/ika-rwth-aachen/docker-ros-ml-images/pull/1