### PR TITLE
Fix platform issues in GitLab

### DIFF
--- a/.github/workflows/gitlab.yml
+++ b/.github/workflows/gitlab.yml
@@ -13,8 +13,8 @@ jobs:
       - name: Upload pipeline ID
         uses: actions/upload-artifact@v3
         with:
-          name: id
-          path: id
+          name: id_ros
+          path: id_ros
 
   watch-ros:
     runs-on: ubuntu-latest
@@ -23,10 +23,10 @@ jobs:
       - name: Get pipeline ID
         uses: actions/download-artifact@v3
         with:
-          name: id
+          name: id_ros
       - name: Wait for pipeline completion
         run: |
-          PIPELINE_ID=$(cat id)
+          PIPELINE_ID=$(cat id_ros)
           while true; do
             sleep 30
             PIPELINE_STATUS=$(curl --silent --header "PRIVATE-TOKEN: ${{ secrets.DOCKER_ROS_CI_READ_PIPELINE_GITLAB_TOKEN }}" "https://gitlab.ika.rwth-aachen.de/api/v4/projects/1886/pipelines/$PIPELINE_ID" | jq -r .status)
@@ -49,8 +49,8 @@ jobs:
       - name: Upload pipeline ID
         uses: actions/upload-artifact@v3
         with:
-          name: id
-          path: id
+          name: id_ros2
+          path: id_ros2
 
   watch-ros2:
     runs-on: ubuntu-latest
@@ -59,10 +59,10 @@ jobs:
       - name: Get pipeline ID
         uses: actions/download-artifact@v3
         with:
-          name: id
+          name: id_ros2
       - name: Wait for pipeline completion
         run: |
-          PIPELINE_ID=$(cat id)
+          PIPELINE_ID=$(cat id_ros2)
           while true; do
             sleep 30
             PIPELINE_STATUS=$(curl --silent --header "PRIVATE-TOKEN: ${{ secrets.DOCKER_ROS_CI_READ_PIPELINE_GITLAB_TOKEN }}" "https://gitlab.ika.rwth-aachen.de/api/v4/projects/1886/pipelines/$PIPELINE_ID" | jq -r .status)

--- a/.github/workflows/gitlab.yml
+++ b/.github/workflows/gitlab.yml
@@ -26,7 +26,7 @@ jobs:
           name: id_ros
       - name: Wait for pipeline completion
         run: |
-          PIPELINE_ID=$(cat id_ros)
+          PIPELINE_ID=$(cat id)
           while true; do
             sleep 30
             PIPELINE_STATUS=$(curl --silent --header "PRIVATE-TOKEN: ${{ secrets.DOCKER_ROS_CI_READ_PIPELINE_GITLAB_TOKEN }}" "https://gitlab.ika.rwth-aachen.de/api/v4/projects/1886/pipelines/$PIPELINE_ID" | jq -r .status)
@@ -62,7 +62,7 @@ jobs:
           name: id_ros2
       - name: Wait for pipeline completion
         run: |
-          PIPELINE_ID=$(cat id_ros2)
+          PIPELINE_ID=$(cat id)
           while true; do
             sleep 30
             PIPELINE_STATUS=$(curl --silent --header "PRIVATE-TOKEN: ${{ secrets.DOCKER_ROS_CI_READ_PIPELINE_GITLAB_TOKEN }}" "https://gitlab.ika.rwth-aachen.de/api/v4/projects/1886/pipelines/$PIPELINE_ID" | jq -r .status)

--- a/.github/workflows/gitlab.yml
+++ b/.github/workflows/gitlab.yml
@@ -9,7 +9,7 @@ jobs:
     steps:
       - name: Trigger pipeline
         run: |
-          curl --silent --fail --request POST --form "token=${{ secrets.DOCKER_ROS_CI_TRIGGER_GITLAB_TOKEN }}" --form "ref=main" --form "variables[DOCKER_ROS_GIT_REF]=${{ github.sha }}" "https://gitlab.ika.rwth-aachen.de/api/v4/projects/1886/trigger/pipeline" | jq -r .id > id
+          curl --silent --fail --request POST --form "token=${{ secrets.DOCKER_ROS_CI_TRIGGER_GITLAB_TOKEN }}" --form "ref=main" --form "variables[DOCKER_ROS_GIT_REF]=${{ github.sha }}" "https://gitlab.ika.rwth-aachen.de/api/v4/projects/1886/trigger/pipeline" | jq -r .id > id_ros
       - name: Upload pipeline ID
         uses: actions/upload-artifact@v3
         with:
@@ -45,7 +45,7 @@ jobs:
     steps:
       - name: Trigger pipeline
         run: |
-          curl --silent --fail --request POST --form "token=${{ secrets.DOCKER_ROS_CI_TRIGGER_GITLAB_TOKEN }}" --form "ref=ros2" --form "variables[DOCKER_ROS_GIT_REF]=${{ github.sha }}" "https://gitlab.ika.rwth-aachen.de/api/v4/projects/1886/trigger/pipeline" | jq -r .id > id
+          curl --silent --fail --request POST --form "token=${{ secrets.DOCKER_ROS_CI_TRIGGER_GITLAB_TOKEN }}" --form "ref=ros2" --form "variables[DOCKER_ROS_GIT_REF]=${{ github.sha }}" "https://gitlab.ika.rwth-aachen.de/api/v4/projects/1886/trigger/pipeline" | jq -r .id > id_ros2
       - name: Upload pipeline ID
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/gitlab.yml
+++ b/.github/workflows/gitlab.yml
@@ -9,12 +9,12 @@ jobs:
     steps:
       - name: Trigger pipeline
         run: |
-          curl --silent --fail --request POST --form "token=${{ secrets.DOCKER_ROS_CI_TRIGGER_GITLAB_TOKEN }}" --form "ref=main" --form "variables[DOCKER_ROS_GIT_REF]=${{ github.sha }}" "https://gitlab.ika.rwth-aachen.de/api/v4/projects/1886/trigger/pipeline" | jq -r .id > id_ros
+          curl --silent --fail --request POST --form "token=${{ secrets.DOCKER_ROS_CI_TRIGGER_GITLAB_TOKEN }}" --form "ref=main" --form "variables[DOCKER_ROS_GIT_REF]=${{ github.sha }}" "https://gitlab.ika.rwth-aachen.de/api/v4/projects/1886/trigger/pipeline" | jq -r .id > id
       - name: Upload pipeline ID
         uses: actions/upload-artifact@v3
         with:
           name: id_ros
-          path: id_ros
+          path: id
 
   watch-ros:
     runs-on: ubuntu-latest
@@ -45,12 +45,12 @@ jobs:
     steps:
       - name: Trigger pipeline
         run: |
-          curl --silent --fail --request POST --form "token=${{ secrets.DOCKER_ROS_CI_TRIGGER_GITLAB_TOKEN }}" --form "ref=ros2" --form "variables[DOCKER_ROS_GIT_REF]=${{ github.sha }}" "https://gitlab.ika.rwth-aachen.de/api/v4/projects/1886/trigger/pipeline" | jq -r .id > id_ros2
+          curl --silent --fail --request POST --form "token=${{ secrets.DOCKER_ROS_CI_TRIGGER_GITLAB_TOKEN }}" --form "ref=ros2" --form "variables[DOCKER_ROS_GIT_REF]=${{ github.sha }}" "https://gitlab.ika.rwth-aachen.de/api/v4/projects/1886/trigger/pipeline" | jq -r .id > id
       - name: Upload pipeline ID
         uses: actions/upload-artifact@v3
         with:
           name: id_ros2
-          path: id_ros2
+          path: id
 
   watch-ros2:
     runs-on: ubuntu-latest

--- a/.gitlab-ci/docker-ros.yml
+++ b/.gitlab-ci/docker-ros.yml
@@ -185,9 +185,8 @@ Test dev-amd64:
   extends: .test
   needs:
     - job: dev-amd64
-      optional: true
   rules:
-    - if: $ENABLE_INDUSTRIAL_CI == 'true' && $PLATFORM =~ /.*amd64.*/
+    - if: $ENABLE_INDUSTRIAL_CI == 'true' && $PLATFORM =~ /.*amd64.*/ && $TARGET =~ /.*dev.*/
   variables:
     DOCKER_IMAGE: ${_IMAGE_DEV_CI_AMD64}
     _PLATFORM: amd64
@@ -198,11 +197,32 @@ Test dev-arm64:
   tags: [privileged, arm64]
   needs:
     - job: dev-arm64
-      optional: true
   rules:
-      - if: $ENABLE_INDUSTRIAL_CI == 'true' && $PLATFORM =~ /.*arm64.*/
+      - if: $ENABLE_INDUSTRIAL_CI == 'true' && $PLATFORM =~ /.*arm64.*/ && $TARGET =~ /.*dev.*/
   variables:
     DOCKER_IMAGE: ${_IMAGE_DEV_CI_ARM64}
+    _PLATFORM: arm64
+
+Test run-amd64:
+  stage: Test ROS Industrial CI
+  extends: .test
+  needs:
+    - job: run-amd64
+  rules:
+    - if: $ENABLE_INDUSTRIAL_CI == 'true' && $PLATFORM =~ /.*amd64.*/ && ! $TARGET =~ /.*dev.*/
+  variables:
+    DOCKER_IMAGE: ${_IMAGE_RUN_CI_AMD64}
+    _PLATFORM: amd64
+
+Test run-arm64:
+  stage: Test ROS Industrial CI
+  extends: .test
+  needs:
+    - job: run-arm64
+  rules:
+    - if: $ENABLE_INDUSTRIAL_CI == 'true' && $PLATFORM =~ /.*arm64.*/ && ! $TARGET =~ /.*dev.*/
+  variables:
+    DOCKER_IMAGE: ${_IMAGE_RUN_CI_ARM64}
     _PLATFORM: arm64
 
 
@@ -219,6 +239,10 @@ Test dev-arm64:
     - job: Test dev-amd64
       optional: true
     - job: Test dev-arm64
+      optional: true
+    - job: Test run-amd64
+      optional: true
+    - job: Test run-arm64
       optional: true
   rules:
     - if: $PLATFORM == '' || $TARGET == ''

--- a/.gitlab-ci/docker-ros.yml
+++ b/.gitlab-ci/docker-ros.yml
@@ -209,7 +209,7 @@ Test run-amd64:
   needs:
     - job: run-amd64
   rules:
-    - if: $ENABLE_INDUSTRIAL_CI == 'true' && $PLATFORM =~ /.*amd64.*/ && ! $TARGET =~ /.*dev.*/
+    - if: $ENABLE_INDUSTRIAL_CI == 'true' && $PLATFORM =~ /.*amd64.*/ && $TARGET !~ /.*dev.*/
   variables:
     DOCKER_IMAGE: ${_IMAGE_RUN_CI_AMD64}
     _PLATFORM: amd64
@@ -220,7 +220,7 @@ Test run-arm64:
   needs:
     - job: run-arm64
   rules:
-    - if: $ENABLE_INDUSTRIAL_CI == 'true' && $PLATFORM =~ /.*arm64.*/ && ! $TARGET =~ /.*dev.*/
+    - if: $ENABLE_INDUSTRIAL_CI == 'true' && $PLATFORM =~ /.*arm64.*/ && $TARGET !~ /.*dev.*/
   variables:
     DOCKER_IMAGE: ${_IMAGE_RUN_CI_ARM64}
     _PLATFORM: arm64

--- a/.gitlab-ci/docker-ros.yml
+++ b/.gitlab-ci/docker-ros.yml
@@ -10,7 +10,7 @@ workflow:
 
 variables:
   TARGET:                     run                                     # Target stage of Dockerfile (comma-separated list) [dev|run]
-  PLATFORM:                   ${CI_RUNNER_EXECUTABLE_ARCH}            # Target platform architecture (comma-separated list) [amd64|arm64|...]
+  PLATFORM:                   amd64                                   # Target platform architecture (comma-separated list) [amd64|arm64|...]
   BASE_IMAGE:                 ''                                      # Base image name:tag (required)
   COMMAND:                    ''                                      # Launch command of run image (required if target=run)
   IMAGE_NAME:                 ${CI_REGISTRY_IMAGE}                    # Image name of run image
@@ -77,7 +77,6 @@ default:
     - privileged
     - amd64
   before_script:
-    - if [[ ${_PLATFORM} ]]  && ! [[ "${PLATFORM}" =~ ${_PLATFORM} ]]; then echo "Platform '${_PLATFORM}' is skipped; can be enabled by adding '${_PLATFORM}' to the 'PLATFORM' variable" && exit 0; fi
     - echo -e "section_start:`date +%s`:setup_section[collapsed=true]\r\e[0K[docker-ros] Setup docker-ros"
     - apk add bash
     - cd ${BUILD_CONTEXT}
@@ -110,7 +109,7 @@ dev-amd64:
   stage: Build dev Images
   extends: .build
   rules:
-    - if: $TARGET =~ /.*dev.*/
+    - if: $PLATFORM =~ /.*amd64.*/ && $TARGET =~ /.*dev.*/
   variables:
     _PLATFORM: amd64
     _TARGET: dev
@@ -123,7 +122,7 @@ dev-arm64:
   extends: .build
   tags: [privileged, arm64]
   rules:
-    - if: $TARGET =~ /.*dev.*/
+    - if: $PLATFORM =~ /.*arm64.*/ && $TARGET =~ /.*dev.*/
   variables:
     _PLATFORM: arm64
     _TARGET: dev
@@ -138,7 +137,7 @@ run-amd64:
     - job: dev-amd64
       optional: true
   rules:
-    - if: $TARGET =~ /.*run.*/
+    - if: $PLATFORM =~ /.*amd64.*/ && $TARGET =~ /.*run.*/
   variables:
     _PLATFORM: amd64
     _TARGET: run
@@ -154,7 +153,7 @@ run-arm64:
     - job: dev-arm64
       optional: true
   rules:
-    - if: $TARGET =~ /.*run.*/
+    - if: $PLATFORM =~ /.*arm64.*/ && $TARGET =~ /.*run.*/
   variables:
     _PLATFORM: arm64
     _TARGET: run
@@ -171,7 +170,6 @@ run-arm64:
     AFTER_INIT_EMBED: git config --global url.https://${GIT_HTTPS_USER}:${GIT_HTTPS_PASSWORD}@${GIT_HTTPS_SERVER}.insteadOf https://${GIT_HTTPS_SERVER}
     DOCKER_RUN_OPTS: -u root:root
   before_script:
-    - if [[ ${_PLATFORM} ]]  && ! [[ "${PLATFORM}" =~ ${_PLATFORM} ]]; then echo "Platform '${_PLATFORM}' is skipped; can be enabled by adding '${_PLATFORM}' to the 'PLATFORM' variable" && exit 0; fi
     - docker login -u ${REGISTRY_USER} -p ${REGISTRY_PASSWORD} ${REGISTRY}
     - apk add --update bash coreutils grep tar
     - |-
@@ -189,7 +187,7 @@ Test dev-amd64:
     - job: dev-amd64
       optional: true
   rules:
-    - if: $ENABLE_INDUSTRIAL_CI == 'true'
+    - if: $ENABLE_INDUSTRIAL_CI == 'true' && $PLATFORM =~ /.*amd64.*/
   variables:
     DOCKER_IMAGE: ${_IMAGE_DEV_CI_AMD64}
     _PLATFORM: amd64
@@ -202,7 +200,7 @@ Test dev-arm64:
     - job: dev-arm64
       optional: true
   rules:
-      - if: $ENABLE_INDUSTRIAL_CI == 'true'
+      - if: $ENABLE_INDUSTRIAL_CI == 'true' && $PLATFORM =~ /.*arm64.*/
   variables:
     DOCKER_IMAGE: ${_IMAGE_DEV_CI_ARM64}
     _PLATFORM: arm64

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ jobs:
   docker-ros:
     runs-on: ubuntu-latest
     steps:
-      - uses: ika-rwth-aachen/docker-ros@v1.2.0
+      - uses: ika-rwth-aachen/docker-ros@v1.2.2
         with:
           base-image: rwthika/ros2:humble
           command: ros2 run my_pkg my_node
@@ -110,7 +110,7 @@ jobs:
 
 ```yml
 include:
-  - remote: https://raw.githubusercontent.com/ika-rwth-aachen/docker-ros/v1.2.0/.gitlab-ci/docker-ros.yml
+  - remote: https://raw.githubusercontent.com/ika-rwth-aachen/docker-ros/v1.2.2/.gitlab-ci/docker-ros.yml
 
 variables:
   BASE_IMAGE: rwthika/ros2:humble
@@ -129,7 +129,7 @@ jobs:
   docker-ros:
     runs-on: ubuntu-latest
     steps:
-      - uses: ika-rwth-aachen/docker-ros@v1.2.0
+      - uses: ika-rwth-aachen/docker-ros@v1.2.2
         with:
           base-image: rwthika/ros2:humble
           command: ros2 run my_pkg my_node
@@ -142,7 +142,7 @@ jobs:
 
 ```yml
 include:
-  - remote: https://raw.githubusercontent.com/ika-rwth-aachen/docker-ros/v1.2.0/.gitlab-ci/docker-ros.yml
+  - remote: https://raw.githubusercontent.com/ika-rwth-aachen/docker-ros/v1.2.2/.gitlab-ci/docker-ros.yml
 
 variables:
   BASE_IMAGE: rwthika/ros2:humble
@@ -162,7 +162,7 @@ jobs:
   docker-ros:
     runs-on: ubuntu-latest
     steps:
-      - uses: ika-rwth-aachen/docker-ros@v1.2.0
+      - uses: ika-rwth-aachen/docker-ros@v1.2.2
         with:
           base-image: rwthika/ros2:humble
           command: ros2 run my_pkg my_node
@@ -176,7 +176,7 @@ jobs:
 
 ```yml
 include:
-  - remote: https://raw.githubusercontent.com/ika-rwth-aachen/docker-ros/v1.2.0/.gitlab-ci/docker-ros.yml
+  - remote: https://raw.githubusercontent.com/ika-rwth-aachen/docker-ros/v1.2.2/.gitlab-ci/docker-ros.yml
 
 variables:
   BASE_IMAGE: rwthika/ros2:humble
@@ -197,7 +197,7 @@ jobs:
   docker-ros:
     runs-on: ubuntu-latest
     steps:
-      - uses: ika-rwth-aachen/docker-ros@v1.2.0
+      - uses: ika-rwth-aachen/docker-ros@v1.2.2
         with:
           base-image: rwthika/ros2:humble
           command: ros2 run my_pkg my_node
@@ -210,7 +210,7 @@ jobs:
 
 ```yml
 include:
-  - remote: https://raw.githubusercontent.com/ika-rwth-aachen/docker-ros/v1.2.0/.gitlab-ci/docker-ros.yml
+  - remote: https://raw.githubusercontent.com/ika-rwth-aachen/docker-ros/v1.2.2/.gitlab-ci/docker-ros.yml
 
 variables:
   BASE_IMAGE: rwthika/ros2:humble
@@ -234,7 +234,7 @@ jobs:
         platform: [amd64, arm64]  
     runs-on: [self-hosted, "${{ matrix.platform }}"]
     steps:
-      - uses: ika-rwth-aachen/docker-ros@v1.2.0
+      - uses: ika-rwth-aachen/docker-ros@v1.2.2
         with:
           base-image: rwthika/ros2:humble
           command: ros2 run my_pkg my_node
@@ -385,7 +385,7 @@ Create a folder `additional-files` in your `docker` folder (or configure a diffe
   *default:* `latest`  
 - **`platform` | `PLATFORM`**  
   Target platform architecture (comma-separated list)  
-  *default:* runner architecture
+  *default:* runner architecture | `amd64`
   *supported values:* `amd64`, `arm64`
 - **`registry` | `REGISTRY`**  
   Docker registry to push images to  


### PR DESCRIPTION
### Problem (GitLab only)

- `PLATFORM` defaults to `$CI_RUNNER_ARCH` in GitLab
- `$CI_RUNNER_ARCH` cannot be checked in `rules:`, as it is only populated once a GitLab runner picks the job
- that's why we are currently always starting `arm64` jobs, even if disabled, and then do nothing in those jobs
- at least two problems arise
  - pipeline fails if no `arm64` runners are available
  - push job also defaults to only push `$CI_RUNNER_ARCH`, thereby currently breaking the multiarch images

### Solution

- let `PLATFORM` default to `amd64`
- use `rules:` to check whether jobs needs to be added to the pipeline