### PR TITLE
[GitLab] Push regular images instead of manifest in case of single arch

### DIFF
--- a/.gitlab-ci/docker-ros.yml
+++ b/.gitlab-ci/docker-ros.yml
@@ -260,19 +260,23 @@ Test run-arm64:
         fi
       elif [[ "${PLATFORM}" =~ amd64 ]]; then
         if [[ "${TARGET}" =~ dev ]]; then
+          docker pull ${_IMAGE_DEV_CI_AMD64}
           docker tag ${_IMAGE_DEV_CI_AMD64} ${IMG_DEV}
           docker push ${IMG_DEV}
         fi
         if [[ "${TARGET}" =~ run ]]; then
+          docker pull ${_IMAGE_RUN_CI_AMD64}
           docker tag ${_IMAGE_RUN_CI_AMD64} ${IMG_RUN}
           docker push ${IMG_RUN}
         fi
       elif [[ "${PLATFORM}" =~ arm64 ]]; then
         if [[ "${TARGET}" =~ dev ]]; then
+          docker pull ${_IMAGE_DEV_CI_ARM64}
           docker tag ${_IMAGE_DEV_CI_ARM64} ${IMG_DEV}
           docker push ${IMG_DEV}
         fi
         if [[ "${TARGET}" =~ run ]]; then
+          docker pull ${_IMAGE_RUN_CI_ARM64}
           docker tag ${_IMAGE_RUN_CI_ARM64} ${IMG_RUN}
           docker push ${IMG_RUN}
         fi

--- a/.gitlab-ci/docker-ros.yml
+++ b/.gitlab-ci/docker-ros.yml
@@ -250,18 +250,33 @@ Test run-arm64:
   script:
     - |-
       if [[ "${PLATFORM}" =~ amd64 && "${PLATFORM}" =~ arm64 ]]; then
-        if [[ "${TARGET}" =~ dev ]]; then docker manifest create ${IMG_DEV} --amend ${_IMAGE_DEV_CI_AMD64} --amend ${_IMAGE_DEV_CI_ARM64}; fi
-        if [[ "${TARGET}" =~ run ]]; then docker manifest create ${IMG_RUN} --amend ${_IMAGE_RUN_CI_AMD64} --amend ${_IMAGE_RUN_CI_ARM64}; fi
+        if [[ "${TARGET}" =~ dev ]]; then
+          docker manifest create ${IMG_DEV} --amend ${_IMAGE_DEV_CI_AMD64} --amend ${_IMAGE_DEV_CI_ARM64}
+          docker manifest push ${IMG_DEV}
+        fi
+        if [[ "${TARGET}" =~ run ]]; then
+          docker manifest create ${IMG_RUN} --amend ${_IMAGE_RUN_CI_AMD64} --amend ${_IMAGE_RUN_CI_ARM64}
+          docker manifest push ${IMG_RUN}
+        fi
       elif [[ "${PLATFORM}" =~ amd64 ]]; then
-        if [[ "${TARGET}" =~ dev ]]; then docker manifest create ${IMG_DEV} --amend ${_IMAGE_DEV_CI_AMD64}; fi
-        if [[ "${TARGET}" =~ run ]]; then docker manifest create ${IMG_RUN} --amend ${_IMAGE_RUN_CI_AMD64}; fi
+        if [[ "${TARGET}" =~ dev ]]; then
+          docker tag ${_IMAGE_DEV_CI_AMD64} ${IMG_DEV}
+          docker push ${IMG_DEV}
+        fi
+        if [[ "${TARGET}" =~ run ]]; then
+          docker tag ${_IMAGE_RUN_CI_AMD64} ${IMG_RUN}
+          docker push ${IMG_RUN}
+        fi
       elif [[ "${PLATFORM}" =~ arm64 ]]; then
-        if [[ "${TARGET}" =~ dev ]]; then docker manifest create ${IMG_DEV} --amend ${_IMAGE_DEV_CI_ARM64}; fi
-        if [[ "${TARGET}" =~ run ]]; then docker manifest create ${IMG_RUN} --amend ${_IMAGE_RUN_CI_ARM64}; fi
+        if [[ "${TARGET}" =~ dev ]]; then
+          docker tag ${_IMAGE_DEV_CI_ARM64} ${IMG_DEV}
+          docker push ${IMG_DEV}
+        fi
+        if [[ "${TARGET}" =~ run ]]; then
+          docker tag ${_IMAGE_RUN_CI_ARM64} ${IMG_RUN}
+          docker push ${IMG_RUN}
+        fi
       fi
-    - |-
-      if [[ "${TARGET}" =~ dev ]]; then docker manifest push ${IMG_DEV}; fi
-      if [[ "${TARGET}" =~ run ]]; then docker manifest push ${IMG_RUN}; fi
 
 Push CI:
   stage: Push Multi-Arch Images


### PR DESCRIPTION
- if only one platform/arch is enabled, final images are not pushed as manifest lists anymore
- this allows to later amend them to other manifest lists
- no changes for GitHub action, since that one does not yet have manifest support