### PR TITLE
Fix rosdep install for non-ROS base images

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ jobs:
   docker-ros:
     runs-on: ubuntu-latest
     steps:
-      - uses: ika-rwth-aachen/docker-ros@v1.2.3
+      - uses: ika-rwth-aachen/docker-ros@v1.2.5
         with:
           base-image: rwthika/ros2:humble
           command: ros2 run my_pkg my_node
@@ -110,7 +110,7 @@ jobs:
 
 ```yml
 include:
-  - remote: https://raw.githubusercontent.com/ika-rwth-aachen/docker-ros/v1.2.3/.gitlab-ci/docker-ros.yml
+  - remote: https://raw.githubusercontent.com/ika-rwth-aachen/docker-ros/v1.2.5/.gitlab-ci/docker-ros.yml
 
 variables:
   BASE_IMAGE: rwthika/ros2:humble
@@ -129,7 +129,7 @@ jobs:
   docker-ros:
     runs-on: ubuntu-latest
     steps:
-      - uses: ika-rwth-aachen/docker-ros@v1.2.3
+      - uses: ika-rwth-aachen/docker-ros@v1.2.5
         with:
           base-image: rwthika/ros2:humble
           command: ros2 run my_pkg my_node
@@ -142,7 +142,7 @@ jobs:
 
 ```yml
 include:
-  - remote: https://raw.githubusercontent.com/ika-rwth-aachen/docker-ros/v1.2.3/.gitlab-ci/docker-ros.yml
+  - remote: https://raw.githubusercontent.com/ika-rwth-aachen/docker-ros/v1.2.5/.gitlab-ci/docker-ros.yml
 
 variables:
   BASE_IMAGE: rwthika/ros2:humble
@@ -162,7 +162,7 @@ jobs:
   docker-ros:
     runs-on: ubuntu-latest
     steps:
-      - uses: ika-rwth-aachen/docker-ros@v1.2.3
+      - uses: ika-rwth-aachen/docker-ros@v1.2.5
         with:
           base-image: rwthika/ros2:humble
           command: ros2 run my_pkg my_node
@@ -176,7 +176,7 @@ jobs:
 
 ```yml
 include:
-  - remote: https://raw.githubusercontent.com/ika-rwth-aachen/docker-ros/v1.2.3/.gitlab-ci/docker-ros.yml
+  - remote: https://raw.githubusercontent.com/ika-rwth-aachen/docker-ros/v1.2.5/.gitlab-ci/docker-ros.yml
 
 variables:
   BASE_IMAGE: rwthika/ros2:humble
@@ -197,7 +197,7 @@ jobs:
   docker-ros:
     runs-on: ubuntu-latest
     steps:
-      - uses: ika-rwth-aachen/docker-ros@v1.2.3
+      - uses: ika-rwth-aachen/docker-ros@v1.2.5
         with:
           base-image: rwthika/ros2:humble
           command: ros2 run my_pkg my_node
@@ -210,7 +210,7 @@ jobs:
 
 ```yml
 include:
-  - remote: https://raw.githubusercontent.com/ika-rwth-aachen/docker-ros/v1.2.3/.gitlab-ci/docker-ros.yml
+  - remote: https://raw.githubusercontent.com/ika-rwth-aachen/docker-ros/v1.2.5/.gitlab-ci/docker-ros.yml
 
 variables:
   BASE_IMAGE: rwthika/ros2:humble
@@ -234,7 +234,7 @@ jobs:
         platform: [amd64, arm64]  
     runs-on: [self-hosted, "${{ matrix.platform }}"]
     steps:
-      - uses: ika-rwth-aachen/docker-ros@v1.2.3
+      - uses: ika-rwth-aachen/docker-ros@v1.2.5
         with:
           base-image: rwthika/ros2:humble
           command: ros2 run my_pkg my_node

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -31,8 +31,7 @@ RUN apt-get update && \
         python3-rosdep \
         python3-vcstool \
         ros-${ROS_DISTRO}-ros-environment \
-    && rm -rf /var/lib/apt/lists/* && \
-    source /opt/ros/${ROS_DISTRO}/setup.bash
+    && rm -rf /var/lib/apt/lists/*
 
 # copy contents of repository
 COPY . src/target

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -30,7 +30,9 @@ RUN apt-get update && \
         git \
         python3-rosdep \
         python3-vcstool \
-    && rm -rf /var/lib/apt/lists/*
+        ros-${ROS_DISTRO}-ros-environment \
+    && rm -rf /var/lib/apt/lists/* && \
+    source /opt/ros/${ROS_DISTRO}/setup.bash
 
 # copy contents of repository
 COPY . src/target
@@ -154,6 +156,7 @@ RUN apt-get update && \
         gosu \
         python-is-python3 \
         python3-pip \
+        ros-${ROS_DISTRO}-ros-environment \
     && rm -rf /var/lib/apt/lists/*
 
 # copy install script from dependencies stage
@@ -165,7 +168,7 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 
 # install ROS CLI tools
-RUN source /opt/ros/$ROS_DISTRO/setup.bash && \
+RUN source /opt/ros/${ROS_DISTRO}/setup.bash && \
     apt-get update && \
     if [[ "$ROS_VERSION" == "1" ]]; then \
         apt-get install -y \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -61,7 +61,7 @@ RUN /usr/local/bin/recursive_vcs_import.py src src/upstream
 
 # create install script with list of rosdep dependencies
 RUN echo "set -e" >> $WORKSPACE/.install-dependencies.sh && \
-    source /opt/ros/${ROS_DISTRO}/setup.bash && \
+    source $(find /opt/ros/$ROS_DISTRO/share/ros_environment -name "1.ros_version.sh") && \
     apt-get update && \
     rosdep init || true && \
     rosdep update --rosdistro ${ROS_DISTRO} && \
@@ -168,7 +168,7 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 
 # install ROS CLI tools
-RUN source /opt/ros/${ROS_DISTRO}/setup.bash && \
+RUN source $(find /opt/ros/$ROS_DISTRO/share/ros_environment -name "1.ros_version.sh") && \
     apt-get update && \
     if [[ "$ROS_VERSION" == "1" ]]; then \
         apt-get install -y \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -62,6 +62,7 @@ RUN /usr/local/bin/recursive_vcs_import.py src src/upstream
 
 # create install script with list of rosdep dependencies
 RUN echo "set -e" >> $WORKSPACE/.install-dependencies.sh && \
+    source /opt/ros/${ROS_DISTRO}/setup.bash && \
     apt-get update && \
     rosdep init || true && \
     rosdep update --rosdistro ${ROS_DISTRO} && \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -30,7 +30,7 @@ RUN apt-get update && \
         git \
         python3-rosdep \
         python3-vcstool \
-        ros-${ROS_DISTRO}-ros-environment \
+        ros-${ROS_DISTRO}-ros-core \
     && rm -rf /var/lib/apt/lists/*
 
 # copy contents of repository
@@ -61,7 +61,7 @@ RUN /usr/local/bin/recursive_vcs_import.py src src/upstream
 
 # create install script with list of rosdep dependencies
 RUN echo "set -e" >> $WORKSPACE/.install-dependencies.sh && \
-    source $(find /opt/ros/$ROS_DISTRO/share/ros_environment -name "1.ros_version.sh") && \
+    source /opt/ros/$ROS_DISTRO/setup.bash && \
     apt-get update && \
     rosdep init || true && \
     rosdep update --rosdistro ${ROS_DISTRO} && \
@@ -156,7 +156,7 @@ RUN apt-get update && \
         gosu \
         python-is-python3 \
         python3-pip \
-        ros-${ROS_DISTRO}-ros-environment \
+        ros-${ROS_DISTRO}-ros-core \
     && rm -rf /var/lib/apt/lists/*
 
 # copy install script from dependencies stage
@@ -168,7 +168,7 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 
 # install ROS CLI tools
-RUN source $(find /opt/ros/$ROS_DISTRO/share/ros_environment -name "1.ros_version.sh") && \
+RUN source /opt/ros/$ROS_DISTRO/setup.bash && \
     apt-get update && \
     if [[ "$ROS_VERSION" == "1" ]]; then \
         apt-get install -y \

--- a/docker/recursive_vcs_import.py
+++ b/docker/recursive_vcs_import.py
@@ -6,7 +6,7 @@ import sys
 from typing import List, Optional
 
 
-def findDotRepos(search_path: str, clone_path: Optional[str]=None) -> List[pathlib.Path]:
+def findDotRepos(search_path: str, clone_path: Optional[str] = None) -> List[pathlib.Path]:
 
     repos = list(pathlib.Path(search_path).glob("**/*.repos"))
     if clone_path is not None:
@@ -32,9 +32,9 @@ def main():
             proc = subprocess.run(["vcs", "import", clone_path, "--recursive"], stdin=f)
             if proc.returncode != 0:
                 raise RuntimeError("vcs import failed")
-        
+
         cloned_repos.append(next_repo)
-        
+
     print(" ".join([str(repo) for repo in set(found_repos)]))
 
 


### PR DESCRIPTION
Always installing `ros-${ROS_DISTRO}-ros-core` and sourcing ROS before `rosdep` ensures that `ROS_VERSION` is set for every base-image (especially for using non-ROS base-images) and that standard ROS2 CLI tools like `rosrun` are always installed.