### PR TITLE
Add option to skip .repo files in the cloned repository

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -56,7 +56,8 @@ COPY docker/docker-ros/docker/recursive_vcs_import.py /usr/local/bin
 RUN apt-get update && \
     apt-get install -y python-is-python3 && \
     rm -rf /var/lib/apt/lists/*
-RUN /usr/local/bin/recursive_vcs_import.py src src/upstream
+ARG ENABLE_RECURSIVE_CLONED="True"
+RUN /usr/local/bin/recursive_vcs_import.py src src/upstream ${ENABLE_RECURSIVE_CLONED}
 
 # create install script with list of rosdep dependencies
 RUN echo "set -e" >> $WORKSPACE/.install-dependencies.sh && \

--- a/docker/recursive_vcs_import.py
+++ b/docker/recursive_vcs_import.py
@@ -6,7 +6,7 @@ import sys
 from typing import List, Optional
 
 
-def findDotRepos(search_path: str, clone_path: Optional[str]=None) -> List[pathlib.Path]:
+def findDotRepos(search_path: str, clone_path: Optional[str] = None) -> List[pathlib.Path]:
 
     repos = list(pathlib.Path(search_path).glob("**/*.repos"))
     if clone_path is not None:
@@ -17,11 +17,14 @@ def main():
 
     search_path = sys.argv[1] if len(sys.argv) > 1 else "."
     clone_path = sys.argv[2] if len(sys.argv) > 2 else "."
+    recursive_cloned = sys.argv[3].lower() == "true" if len(sys.argv) > 3 else True
     cloned_repos = []
+    found_repos = []
 
     while True:
 
-        found_repos = findDotRepos(search_path, clone_path)
+        if recursive_cloned or not found_repos:
+            found_repos = findDotRepos(search_path, clone_path)
         remaining_repos = set(found_repos) - set(cloned_repos)
 
         if not remaining_repos:

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -30,6 +30,7 @@ build_image() {
         $(if [[ -n "${ENABLE_RECURSIVE_ADDITIONAL_PIP}" ]]; then echo "--build-arg ENABLE_RECURSIVE_ADDITIONAL_PIP=${ENABLE_RECURSIVE_ADDITIONAL_PIP}"; fi) \
         $(if [[ -n "${CUSTOM_SCRIPT_FILE}" ]]; then echo "--build-arg CUSTOM_SCRIPT_FILE=${CUSTOM_SCRIPT_FILE}"; fi) \
         $(if [[ -n "${ENABLE_RECURSIVE_CUSTOM_SCRIPT}" ]]; then echo "--build-arg ENABLE_RECURSIVE_CUSTOM_SCRIPT=${ENABLE_RECURSIVE_CUSTOM_SCRIPT}"; fi) \
+        $(if [[ -n "${ENABLE_RECURSIVE_CLONED}" ]]; then echo "--build-arg ENABLE_RECURSIVE_CLONED=${ENABLE_RECURSIVE_CLONED}"; fi) \
         .
     echo "Successfully built stage '${TARGET}' for platform '${PLATFORM}' as '${IMAGE}'"
 }


### PR DESCRIPTION
I was checking the final install folder and noticed some extra dependencies being built. This was due to some ros2 packages also including their own .repo files. In my case, these packages were already found and installed automatically by rosdep, thus there was no point in manually building them.

In order to keep the previous behavior, I have added a new variable to disable recursively checking the .repo files within the cloned repos. I have decided to keep the current script to still find every .repo files available when calling the build script.