### PR TITLE
Include submodules when using vcs import

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -66,7 +66,7 @@ ARG ENABLE_RECURSIVE_VCS_IMPORT="true"
 RUN if [[ $ENABLE_RECURSIVE_VCS_IMPORT == 'true' ]]; then \
         /usr/local/bin/recursive_vcs_import.py src src/upstream ; \
     else \
-        [[ -f src/target/${VCS_IMPORT_FILE} ]] && vcs import src/upstream < src/target/${VCS_IMPORT_FILE} ; \
+        [[ -f src/target/${VCS_IMPORT_FILE} ]] && vcs import --recursive src/upstream < src/target/${VCS_IMPORT_FILE} ; \
     fi
 
 # remove blacklisted packages from workspace


### PR DESCRIPTION
If the ENABLE_RECURSIVE_VCS_IMPORT flag is set to false, then the repository in .repos is not recursively imported, which is necessary when working with submodules.