### PR TITLE
Feature/checkout configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -362,11 +362,11 @@ Create a folder `additional-files` in your `docker` folder (or configure a diffe
 - **`-` | `DOCKER_ROS_GIT_REF`**  
   Git reference of *docker-ros* to run in CI  
   *default:* `main` 
-- **`enable-checkout` | `( - )`**  
-  Enable [*checkout*](https://github.com/actions/checkout) action to (re-)download your repository prior to running the pipeline
+- **`enable-checkout` | `-`**  
+  Enable [*checkout*](https://github.com/actions/checkout) action to (re-)download your repository prior to running the pipeline  
   *default:* `true`
-- **`enable-checkout-lfs` | `( - )`**  
-  Enable [*git-lfs*](https://git-lfs.com/) support for the [*checkout*](https://github.com/actions/checkout) action
+- **`enable-checkout-lfs` | `-`**  
+  Enable [*git-lfs*](https://git-lfs.com/) support for the [*checkout*](https://github.com/actions/checkout) action  
   *default:* `true` 
 - **`enable-industrial-ci` | `ENABLE_INDUSTRIAL_CI`**  
   Enable [*industrial_ci*](https://github.com/ros-industrial/industrial_ci)  

--- a/README.md
+++ b/README.md
@@ -362,6 +362,12 @@ Create a folder `additional-files` in your `docker` folder (or configure a diffe
 - **`-` | `DOCKER_ROS_GIT_REF`**  
   Git reference of *docker-ros* to run in CI  
   *default:* `main` 
+- **`enable-checkout` | `( - )`**  
+  Enable [*checkout*](https://github.com/actions/checkout) action to (re-)download your repository prior to running the pipeline
+  *default:* `true`
+- **`enable-checkout-lfs` | `( - )`**  
+  Enable [*git-lfs*](https://git-lfs.com/) support for the [*checkout*](https://github.com/actions/checkout) action
+  *default:* `true` 
 - **`enable-industrial-ci` | `ENABLE_INDUSTRIAL_CI`**  
   Enable [*industrial_ci*](https://github.com/ros-industrial/industrial_ci)  
   *default:* `false` 

--- a/action.yml
+++ b/action.yml
@@ -134,7 +134,7 @@ runs:
       if: ${{ inputs.enable-checkout == 'true' }}
       with:
         submodules: true
-        lfs: ${{ enable-checkout-lfs }}
+        lfs: ${{ inputs.enable-checkout-lfs }}
 
     - name: Set up docker-ros
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -131,9 +131,10 @@ runs:
 
     - name: Checkout repository
       uses: actions/checkout@v3
+      if: ${{ inputs.enable-checkout == 'true' }}
       with:
         submodules: true
-        lfs: true
+        lfs: ${{ enable-checkout-lfs }}
 
     - name: Set up docker-ros
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -117,11 +117,11 @@ inputs:
     default: false
 
   enable-checkout:
-    description: "Enable checkout of repository prior to running the pipeline"
+    description: "Enable checkout action to (re-)download your repository prior to running the pipeline"
     default: true
 
   enable-checkout-lfs:
-    description: "Enable download of lfs files for the repository checkout"
+    description: "Enable git-lfs support for the checkout action "
     default: true
 
 

--- a/action.yml
+++ b/action.yml
@@ -116,6 +116,14 @@ inputs:
     description: "Push images with tag `latest`/`latest-dev` in addition to the configured image names"
     default: false
 
+  enable-checkout:
+    description: "Enable checkout of repository prior to running the pipeline"
+    default: true
+
+  enable-checkout-lfs:
+    description: "Enable download of lfs files for the repository checkout"
+    default: true
+
 
 runs:
   using: "composite"


### PR DESCRIPTION
The checkout action before running the actual docker-ros pipeline makes it difficult to move in files/directories for docker-ros to use which are not present in the repository itself (e.g. artifacts produced by other jobs/workflows).

Additionally, the option `lfs: true` of the checkout action leads to a failed pipeline if the executing runner doesn't have git-lfs installed. It makes sense to leave this up to the user, especially if they use self-hosted runners.

These changes allow users to manually disable the checkout action, as well as its git lfs support. Defaults are set to 'true', so existing pipelines based on docker-ros should show no change in behavior.