### PR TITLE
Enforce lower-case image name in GitHub Action

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -19,7 +19,7 @@ inputs:
 
   image-name:
     description: "Image name of run image"
-    default: ghcr.io/${{ lower(github.repository) }}
+    default: ghcr.io/${{ github.repository }}
 
   image-tag:
     description: "Image tag of run image"

--- a/action.yml
+++ b/action.yml
@@ -178,6 +178,12 @@ runs:
       with:
         string: ${{ inputs.image-name }}
 
+    - name: Enforce lower-case dev image name 
+      id: dev-image-name
+      uses: ASzc/change-string-case-action@v6
+      with:
+        string: ${{ inputs.dev-image-name }}
+
     - name: Build images
       id: build-images
       shell: bash
@@ -190,7 +196,7 @@ runs:
         COMMAND: ${{ inputs.command }}
         IMAGE_NAME: ${{ steps.image-name.outputs.lowercase }}
         IMAGE_TAG: ${{ inputs.image-tag }}
-        DEV_IMAGE_NAME: ${{ inputs.dev-image-name }}
+        DEV_IMAGE_NAME: ${{ steps.dev-image-name.outputs.lowercase }}
         DEV_IMAGE_TAG: ${{ inputs.dev-image-tag }}
         RMW_IMPLEMENTATION: ${{ inputs.rmw-implementation }}
         ROS_DISTRO: ${{ inputs.ros-distro }}

--- a/action.yml
+++ b/action.yml
@@ -172,6 +172,12 @@ runs:
     - name: Set up Docker buildx
       uses: docker/setup-buildx-action@v3
 
+    - name: Enforce lower-case image name 
+      id: image-name
+      uses: ASzc/change-string-case-action@v6
+      with:
+        string: ${{ inputs.image-name }}
+
     - name: Build images
       id: build-images
       shell: bash
@@ -182,7 +188,7 @@ runs:
         TARGET: ${{ inputs.target }}
         BASE_IMAGE: ${{ inputs.base-image }}
         COMMAND: ${{ inputs.command }}
-        IMAGE_NAME: ${{ inputs.image-name }}
+        IMAGE_NAME: ${{ steps.image-name.outputs.lowercase }}
         IMAGE_TAG: ${{ inputs.image-tag }}
         DEV_IMAGE_NAME: ${{ inputs.dev-image-name }}
         DEV_IMAGE_TAG: ${{ inputs.dev-image-tag }}
@@ -239,7 +245,7 @@ runs:
         TARGET: ${{ inputs.target }}
         BASE_IMAGE: ${{ inputs.base-image }}
         COMMAND: ${{ inputs.command }}
-        IMAGE_NAME: ${{ inputs.image-name }}
+        IMAGE_NAME: ${{ steps.image-name.outputs.lowercase }}
         IMAGE_TAG: ${{ inputs.image-tag }}
         DEV_IMAGE_NAME: ${{ inputs.dev-image-name }}
         DEV_IMAGE_TAG: ${{ inputs.dev-image-tag }}
@@ -275,7 +281,7 @@ runs:
         TARGET: ${{ inputs.target }}
         BASE_IMAGE: ${{ inputs.base-image }}
         COMMAND: ${{ inputs.command }}
-        IMAGE_NAME: ${{ inputs.image-name }}
+        IMAGE_NAME: ${{ steps.image-name.outputs.lowercase }}
         IMAGE_TAG: latest
         DEV_IMAGE_NAME: ${{ inputs.dev-image-name }}
         DEV_IMAGE_TAG: latest-dev

--- a/action.yml
+++ b/action.yml
@@ -19,7 +19,7 @@ inputs:
 
   image-name:
     description: "Image name of run image"
-    default: ghcr.io/${{ github.repository }}
+    default: ghcr.io/${{ lower(github.repository) }}
 
   image-tag:
     description: "Image tag of run image"


### PR DESCRIPTION
If the GitHub username contains upper-case characters, the docker-ros action fails because the default image name is not lower-case, although that is required.

See also https://github.com/orgs/community/discussions/25768.

This ensures that the default image name is converted into a lower-case string.