### PR TITLE
Ignore empty .repos files in recursive VCS import

### DIFF
--- a/docker/recursive_vcs_import.py
+++ b/docker/recursive_vcs_import.py
@@ -6,13 +6,23 @@ import sys
 from typing import List, Optional
 
 
-def findDotRepos(search_path: str, clone_path: Optional[str] = None) -> List[pathlib.Path]:
+def find_dot_repos(search_path: str, clone_path: Optional[str] = None) -> List[pathlib.Path]:
 
     repos = list(pathlib.Path(search_path).glob("**/*.repos"))
     if clone_path is not None:
         repos.extend(list(pathlib.Path(clone_path).glob("**/*.repos")))
     return repos
 
+def is_file_empty(filename):
+    """Check if file is empty, allowing blank spaces."""
+    try:
+        with open(filename, 'r') as file:
+            content = file.read().strip()
+            return len(content) == 0
+    except Exception as e:
+        print(e)
+        # Exception gets raised later
+        return False
 
 def main():
 
@@ -22,7 +32,7 @@ def main():
 
     while True:
 
-        found_repos = findDotRepos(search_path, clone_path)
+        found_repos = find_dot_repos(search_path, clone_path)
         remaining_repos = set(found_repos) - set(cloned_repos)
 
         if not remaining_repos:
@@ -32,7 +42,11 @@ def main():
         with open(str(next_repo), "r") as f:
             proc = subprocess.run(["vcs", "import", clone_path, "--recursive"], stdin=f)
             if proc.returncode != 0:
-                raise RuntimeError("vcs import failed")
+                # Ignore empty .repos files
+                if not is_file_empty(next_repo):
+                    raise RuntimeError("vcs import failed")
+                else:
+                    print(f"Ignored empty .repos file: {next_repo}")
 
         cloned_repos.append(next_repo)
 
@@ -41,3 +55,4 @@ def main():
 
 if __name__ == "__main__":
     main()
+    


### PR DESCRIPTION
If an upstream repo specified in .repos contains itself an empty .repos file, `vcs import` fails, making it impossible to clone the repo.

Example: Running `vcs import` on https://github.com/tier4/ars408_driver/tree/main results in the error `Input data is not valid format: 'NoneType' object is not subscriptable`.

While technically an empty .repos file is invalid, those cases can easily ignored for the ease-of-use.