### PR TITLE
Add tini as PID 1 process in front of entrypoint

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -220,8 +220,11 @@ RUN source /opt/ros/$ROS_DISTRO/setup.bash && \
 RUN echo "source /opt/ros/$ROS_DISTRO/setup.bash" >> ~/.bashrc
 
 # set entrypoint
+ENV TINI_VERSION v0.19.0
+ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-${TARGETARCH} /tini
+RUN chmod +x /tini
 COPY docker/docker-ros/docker/entrypoint.sh /
-ENTRYPOINT ["/entrypoint.sh"]
+ENTRYPOINT ["/tini", "--", "/entrypoint.sh"]
 
 ############ dev ###############################################################
 FROM dependencies-install as dev


### PR DESCRIPTION
#### Problem

- containers take long to shut down
- reason is that `docker stop` sends `SIGTERM` signal
- [ROS listens for SIGINT](https://wiki.ros.org/roscpp/Overview/Initialization%20and%20Shutdown)
- after 10s, container is killed via `SIGKILL`

#### Solution

- use `tini` as init process: [Why tini?](https://github.com/krallin/tini?tab=readme-ov-file#why-tini)
- [Why Your Dockerized Application Isn’t Receiving Signals](https://hynek.me/articles/docker-signals/)
- correctly forwards signals and speeds up container shutdown
- alternatives
  - `stop_signal: SIGINT` in Docker Compose: works for speeding up shutdown of ROS apps, but doesn't bring tini benefits
  - `docker run --init`: automatically starts containers with tini; works for speeding up shutdown, but is easily forgotten

---

#### Shutdown Evaluation

```yml
services:

  current:
    image: ghcr.io/ika-rwth-aachen/mqtt_client:ros2

  stop-signal:
    image: ghcr.io/ika-rwth-aachen/mqtt_client:ros2
    stop_signal: SIGINT

  tini-by-docker:
    image: ghcr.io/ika-rwth-aachen/mqtt_client:ros2
    init: true

  tini:
    image: mqtt_client # image built by this version of docker-ros
```

```
time docker stop $(basename $(pwd))-current-1
tmp-current-1
docker stop $(basename $(pwd))-current-1  0,05s user 0,04s system 0% cpu 10,316 total
```

```
time docker stop $(basename $(pwd))-stop-signal-1
tmp-stop-signal-1
docker stop $(basename $(pwd))-stop-signal-1  0,05s user 0,04s system 13% cpu 0,624 total
```

```
time docker stop $(basename $(pwd))-tini-by-docker-1
tmp-tini-by-docker-1
docker stop $(basename $(pwd))-tini-by-docker-1 0,05s user 0,04s system 27% cpu 0,310 total
```

```
time docker stop $(basename $(pwd))-tini-1
tmp-tini-1
docker stop $(basename $(pwd))-tini-1  0,05s user 0,03s system 31% cpu 0,262 total
```