### PR TITLE
Improve rosdep simulate output

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -91,7 +91,9 @@ RUN echo "set -e" >> $WORKSPACE/.install-dependencies.sh && \
     export OS="ubuntu:$(lsb_release -c | awk '{print $2}')" && \
     if [[ "$ROS_DISTRO" = "rolling" && "$OS" = "ubuntu:focal" ]]; then export OS="ubuntu:jammy"; fi && \
     set -o pipefail && \
-    ROS_PACKAGE_PATH=$(pwd):$ROS_PACKAGE_PATH rosdep install --os $OS -y --simulate --from-paths src --ignore-src | tee -a $WORKSPACE/.install-dependencies.sh && \
+    ROS_PACKAGE_PATH=$(pwd):$ROS_PACKAGE_PATH rosdep install --os $OS -y --simulate --from-paths src --ignore-src \
+    | sed -E "s/'apt-get install -y ([^']+)' \(alternative 1\/1\)/apt-get install -y \1/" \
+    | tee -a $WORKSPACE/.install-dependencies.sh && \
     chmod +x $WORKSPACE/.install-dependencies.sh && \
     rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
- avoid printing `(alternatives 1/1)`

before (example):
```bash
#[apt] Installation commands:
  apt-get install -y ros-jazzy-rviz2
  'apt-get install -y libqt5gui5t64' (alternative 1/1)
```
after (example):
```bash
#[apt] Installation commands:
  apt-get install -y ros-jazzy-rviz2
  apt-get install -y libqt5gui5t64
```