### PR TITLE
ROS 2 Jazzy Ubuntu 24.04 support | Entry point user/group check | README updates | CI fixes

### DIFF
--- a/.github/workflows/github.yml
+++ b/.github/workflows/github.yml
@@ -1,6 +1,12 @@
 name: GitHub
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
 
 jobs:
 

--- a/.github/workflows/gitlab.yml
+++ b/.github/workflows/gitlab.yml
@@ -1,6 +1,12 @@
 name: GitLab
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
 
 jobs:
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2023 Institute for Automotive Engineering (ika), RWTH Aachen University
+Copyright (c) 2023-2024 Institute for Automotive Engineering (ika), RWTH Aachen University
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@
   - [Extra System Dependencies (*pip*)](#extra-system-dependencies-pip)
   - [Custom Installation Script](#custom-installation-script)
   - [Extra Image Files](#extra-image-files)
+- [Additional Information](#additional-information)
+  - [User Setup](#user-setup)
 - [Configuration Variables](#configuration-variables)
 
 We recommend to use *docker-ros* in combination with our other tools for Docker and ROS.
@@ -330,6 +332,19 @@ Create a script `custom.sh` in your `docker` folder (or configure a different `C
 If you need to have additional files present in the deployment image, you can use a special `additional-files` folder. The folder contents will be copied into the container before the custom installation script `custom.sh` is executed.
 
 Create a folder `additional-files` in your `docker` folder (or configure a different `ADDITIONAL_FILES_DIR`) and place any files or directories in it. The contents will be copied to `/docker-ros/additional-files` in the image.
+
+
+## Additional Information
+
+### User Setup
+
+Containers of the provided images start with `root` user by default. If the two environment variables `DOCKER_UID` and `DOCKER_GID` are passed, a new user with the corresponding UID/GID is created on the fly. Most importantly, this features allows to mount and edit files of the host user in the container without having to deal with permission issues.
+
+```bash
+docker run --rm -it -e DOCKER_UID=$(id -u) -e DOCKER_GID=$(id -g) -e DOCKER_USER=$(id -un) rwthika/ros:latest
+```
+
+The password of the custom user is set to its username (`dockeruser:dockeruser` by default).
 
 
 ## Configuration Variables

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@
   <img src="https://img.shields.io/github/license/ika-rwth-aachen/docker-ros"/>
   <a href="https://github.com/ika-rwth-aachen/docker-ros/actions/workflows/github.yml"><img src="https://github.com/ika-rwth-aachen/docker-ros/actions/workflows/github.yml/badge.svg"/></a>
   <a href="https://github.com/ika-rwth-aachen/docker-ros/actions/workflows/gitlab.yml"><img src="https://github.com/ika-rwth-aachen/docker-ros/actions/workflows/gitlab.yml/badge.svg"/></a>
+  <img src="https://img.shields.io/badge/ROS-noetic-blueviolet"/>
+  <img src="https://img.shields.io/badge/ROS 2-foxy|humble|iron|jazzy-blueviolet"/>
 </p>
 
 *docker-ros* automatically builds minimal container images of ROS applications.
@@ -14,10 +16,8 @@
 > [!IMPORTANT]  
 > This repository is open-sourced and maintained by the [**Institute for Automotive Engineering (ika) at RWTH Aachen University**](https://www.ika.rwth-aachen.de/).  
 > **DevOps, Containerization and Orchestration of Software-Defined Vehicles** are some of many research topics within our [*Vehicle Intelligence & Automated Driving*](https://www.ika.rwth-aachen.de/en/competences/fields-of-research/vehicle-intelligence-automated-driving.html) domain.  
-> If you would like to learn more about how we can support your DevOps or automated driving efforts, feel free to reach out to us!  
-> &nbsp;&nbsp;&nbsp;&nbsp; *Timo Woopen - Manager Research Area Vehicle Intelligence & Automated Driving*  
-> &nbsp;&nbsp;&nbsp;&nbsp; *+49 241 80 23549*  
-> &nbsp;&nbsp;&nbsp;&nbsp; *timo.woopen@ika.rwth-aachen.de*  
+> If you would like to learn more about how we can support your advanced driver assistance and automated driving efforts, feel free to reach out to us!  
+> :email: ***opensource@ika.rwth-aachen.de***
 
 - [About](#about)
   - [Prerequisites](#prerequisites)

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -187,6 +187,10 @@ RUN apt-get update && \
         ros-${ROS_DISTRO}-ros-core \
     && rm -rf /var/lib/apt/lists/*
 
+# configure pip
+RUN mkdir -p ~/.config/pip && \
+    echo -e "[global]\nbreak-system-packages = true" >> ~/.config/pip/pip.conf
+
 # copy install script from dependencies stage
 COPY --from=dependencies $WORKSPACE/.install-dependencies.sh $WORKSPACE/.install-dependencies.sh
 

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -23,8 +23,10 @@ if [[ $DOCKER_UID && $DOCKER_GID ]]; then
                 touch /home/$DOCKER_USER/.sudo_as_admin_successful
         cp /root/.bashrc /home/$DOCKER_USER
         ln -s $WORKSPACE /home/$DOCKER_USER/ws
-        chown -R $DOCKER_UID:$DOCKER_GID $WORKSPACE
-        chown -R $DOCKER_UID:$DOCKER_GID /home/$DOCKER_USER
+        chown -h $DOCKER_UID:$DOCKER_GID $WORKSPACE /home/$DOCKER_USER/ws /home/$DOCKER_USER/.sudo_as_admin_successful
+        if [[ -d $WORKSPACE/src ]]; then
+            chown -R $DOCKER_USER:$DOCKER_USER $WORKSPACE/src
+        fi
     fi
     [[ $(pwd) == "$WORKSPACE" ]] && cd /home/$DOCKER_USER/ws
     exec gosu $DOCKER_USER "$@"

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -8,20 +8,24 @@ source /opt/ros/$ROS_DISTRO/setup.bash
 
 # exec as dockeruser with configured UID/GID
 if [[ $DOCKER_UID && $DOCKER_GID ]]; then
-    groupadd -g $DOCKER_GID $DOCKER_USER
-    useradd -s /bin/bash \
-            -u $DOCKER_UID \
-            -g $DOCKER_USER \
-            --create-home \
-            --home-dir /home/$DOCKER_USER \
-            --groups sudo,video \
-            --password "$(openssl passwd -1 $DOCKER_USER)" \
-            $DOCKER_USER && \
-            touch /home/$DOCKER_USER/.sudo_as_admin_successful
-    cp /root/.bashrc /home/$DOCKER_USER
-    ln -s $WORKSPACE /home/$DOCKER_USER/ws
-    chown -R $DOCKER_USER:$DOCKER_USER $WORKSPACE
-    chown -R $DOCKER_USER:$DOCKER_USER /home/$DOCKER_USER
+    if ! getent group $DOCKER_GID > /dev/null 2>&1; then
+        groupadd -g $DOCKER_GID $DOCKER_USER
+    fi
+    if ! getent passwd $DOCKER_UID > /dev/null 2>&1; then
+        useradd -s /bin/bash \
+                -u $DOCKER_UID \
+                -g $DOCKER_GID \
+                --create-home \
+                --home-dir /home/$DOCKER_USER \
+                --groups sudo,video \
+                --password "$(openssl passwd -1 $DOCKER_USER)" \
+                $DOCKER_USER && \
+                touch /home/$DOCKER_USER/.sudo_as_admin_successful
+        cp /root/.bashrc /home/$DOCKER_USER
+        ln -s $WORKSPACE /home/$DOCKER_USER/ws
+        chown -R $DOCKER_UID:$DOCKER_GID $WORKSPACE
+        chown -R $DOCKER_UID:$DOCKER_GID /home/$DOCKER_USER
+    fi
     [[ $(pwd) == "$WORKSPACE" ]] && cd /home/$DOCKER_USER/ws
     exec gosu $DOCKER_USER "$@"
 else


### PR DESCRIPTION
### ROS 2 Jazzy Ubuntu 24.04 support
- deal with new pip warning ([see here](https://stackoverflow.com/questions/75602063/pip-install-r-requirements-txt-is-failing-this-environment-is-externally-mana))

### Entry point user/group check
- check if new user exists in entrypoint to enable re-starting container without removal
- [see here](https://github.com/ika-rwth-aachen/docker-ros-ml-images/pull/5)

### README updates
- ROS distro badges
- license updates
- contact text updated

### CI fixes
- docker-ros-ci fixed by generating new GitLab token to read pipeline status
- CI now restricted to push to main and pull request to main to avoid duplicate pipelines