### PR TITLE
Use build-in modification of pip.conf

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -188,13 +188,6 @@ RUN apt-get update && \
     && rm -rf /var/lib/apt/lists/*
 
 # configure pip
-# for /usr/pip.conf
-RUN python -m pip config --site set global.break-system-packages true
-
-# for /root/.config/pip/pip.conf
-RUN python -m pip config --user set global.break-system-packages true 
-
-# for /etc/pip.conf
 RUN python -m pip config --global set global.break-system-packages true
 
 # copy install script from dependencies stage

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -188,8 +188,16 @@ RUN apt-get update && \
     && rm -rf /var/lib/apt/lists/*
 
 # configure pip
-RUN mkdir -p ~/.config/pip && \
-    echo -e "[global]\nbreak-system-packages = true" >> ~/.config/pip/pip.conf
+RUN python - <<-"EOF"
+import configparser; import os
+config = configparser.ConfigParser()
+config_file = '/root/.config/pip/pip.conf'
+open(config_file, 'w').close() if not os.path.exists(config_file) else None
+config.read(config_file)
+if 'global' not in config: config['global'] = {}
+config['global']['break-system-packages'] = 'true'
+with open(config_file, 'w') as file: config.write(file)
+EOF
 
 # copy install script from dependencies stage
 COPY --from=dependencies $WORKSPACE/.install-dependencies.sh $WORKSPACE/.install-dependencies.sh

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -188,7 +188,14 @@ RUN apt-get update && \
     && rm -rf /var/lib/apt/lists/*
 
 # configure pip
+# fix /usr/pip.conf
 RUN python -m pip config --site set global.break-system-packages true
+
+# fix /root/.config/pip/pip.conf
+RUN python -m pip config --user set global.break-system-packages true 
+
+# fix /etc/pip.conf
+RUN python -m pip config --global set global.break-system-packages true
 
 # copy install script from dependencies stage
 COPY --from=dependencies $WORKSPACE/.install-dependencies.sh $WORKSPACE/.install-dependencies.sh

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -188,16 +188,7 @@ RUN apt-get update && \
     && rm -rf /var/lib/apt/lists/*
 
 # configure pip
-RUN python - <<-"EOF"
-import configparser; import os
-config = configparser.ConfigParser()
-config_file = '/root/.config/pip/pip.conf'
-open(config_file, 'w').close() if not os.path.exists(config_file) else None
-config.read(config_file)
-if 'global' not in config: config['global'] = {}
-config['global']['break-system-packages'] = 'true'
-with open(config_file, 'w') as file: config.write(file)
-EOF
+RUN python -m pip config --site set global.break-system-packages true
 
 # copy install script from dependencies stage
 COPY --from=dependencies $WORKSPACE/.install-dependencies.sh $WORKSPACE/.install-dependencies.sh

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -188,13 +188,13 @@ RUN apt-get update && \
     && rm -rf /var/lib/apt/lists/*
 
 # configure pip
-# fix /usr/pip.conf
+# for /usr/pip.conf
 RUN python -m pip config --site set global.break-system-packages true
 
-# fix /root/.config/pip/pip.conf
+# for /root/.config/pip/pip.conf
 RUN python -m pip config --user set global.break-system-packages true 
 
-# fix /etc/pip.conf
+# for /etc/pip.conf
 RUN python -m pip config --global set global.break-system-packages true
 
 # copy install script from dependencies stage


### PR DESCRIPTION
- Uses `pip config` command to edit `/root/.config/pip/pip.conf`
- https://pip.pypa.io/en/latest/cli/pip_config/
- No more collisions possible
- Previous behavior: Possibly two sections `[global]` in  `/root/.config/pip/pip.conf` would have been created which causes pip to crash

Note that
```
# [Priority 1] Site level configuration files
#       1. `/usr/pip.conf`
#
# [Priority 2] User level configuration files
#       1. `/root/.config/pip/pip.conf`
#       2. `/root/.pip/pip.conf`
#
# [Priority 3] Global level configuration files
#       1. `/etc/pip.conf`
#       2. `/etc/xdg/pip/pip.conf`
```
Hence we need to execute:

```docker
# for /etc/pip.conf
RUN python -m pip config --global set global.break-system-packages true
```

