### PR TITLE
Update artifact action versions

### DIFF
--- a/.github/workflows/gitlab.yml
+++ b/.github/workflows/gitlab.yml
@@ -17,7 +17,7 @@ jobs:
         run: |
           curl --silent --fail --request POST --form "token=${{ secrets.DOCKER_ROS_CI_TRIGGER_GITLAB_TOKEN }}" --form "ref=main" --form "variables[DOCKER_ROS_GIT_REF]=${{ github.sha }}" "https://gitlab.ika.rwth-aachen.de/api/v4/projects/1886/trigger/pipeline" | jq -r .id > id
       - name: Upload pipeline ID
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: id_ros
           path: id
@@ -27,7 +27,7 @@ jobs:
     needs: trigger-ros
     steps:
       - name: Get pipeline ID
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: id_ros
       - name: Wait for pipeline completion
@@ -53,7 +53,7 @@ jobs:
         run: |
           curl --silent --fail --request POST --form "token=${{ secrets.DOCKER_ROS_CI_TRIGGER_GITLAB_TOKEN }}" --form "ref=ros2" --form "variables[DOCKER_ROS_GIT_REF]=${{ github.sha }}" "https://gitlab.ika.rwth-aachen.de/api/v4/projects/1886/trigger/pipeline" | jq -r .id > id
       - name: Upload pipeline ID
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: id_ros2
           path: id
@@ -63,7 +63,7 @@ jobs:
     needs: trigger-ros2
     steps:
       - name: Get pipeline ID
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: id_ros2
       - name: Wait for pipeline completion


### PR DESCRIPTION
- update version for `download-artifact` and `upload-artifact` to `v4`
- due to security reasons (https://github.com/ika-rwth-aachen/docker-ros/security/dependabot/1)