### PR TITLE
Support usage of `rmw_zenoh`

### DIFF
--- a/README.md
+++ b/README.md
@@ -453,7 +453,7 @@ The password of the custom user is set to its username (`dockeruser:dockeruser` 
 - **`rmw-implementation` | `RMW_IMPLEMENTATION`**  
   ROS 2 middleware implementation  
   *default:* `rmw_cyclonedds_cpp`  
-  *supported values:* `rmw_fastrtps_cpp`, `rmw_cyclonedds_cpp`, `rmw_gurumdds_cpp`, ...  
+  *supported values:* `rmw_zenoh_cpp`, `rmw_fastrtps_cpp`, `rmw_cyclonedds_cpp`, `rmw_gurumdds_cpp`, ...  
 - **`ros-distro` | `ROS_DISTRO`**  
   ROS Distro  
   *required if ROS is not installed in `base-image`*  

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,7 @@
 ARG BASE_IMAGE
 
 ############ dependencies ######################################################
-FROM ${BASE_IMAGE} as dependencies
+FROM ${BASE_IMAGE} AS dependencies
 
 USER root
 SHELL ["/bin/bash", "-c"]
@@ -232,14 +232,14 @@ RUN source /opt/ros/$ROS_DISTRO/setup.bash && \
 RUN echo "source /opt/ros/$ROS_DISTRO/setup.bash" >> ~/.bashrc
 
 # set entrypoint
-ENV TINI_VERSION v0.19.0
+ENV TINI_VERSION=v0.19.0
 ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-${TARGETARCH} /tini
 RUN chmod +x /tini
 COPY docker/docker-ros/docker/entrypoint.sh /
 ENTRYPOINT ["/tini", "--", "/entrypoint.sh"]
 
 ############ dev ###############################################################
-FROM dependencies-install as dev
+FROM dependencies-install AS dev
 
 # copy contents of repository from dependencies stage
 COPY --from=dependencies $WORKSPACE/src $WORKSPACE/src
@@ -247,7 +247,7 @@ COPY --from=dependencies $WORKSPACE/src $WORKSPACE/src
 CMD ["bash"]
 
 ############ build #############################################################
-FROM dev as build
+FROM dev AS build
 
 # build ROS workspace
 RUN if [[ -x "$(command -v colcon)" ]]; then \
@@ -259,7 +259,7 @@ RUN if [[ -x "$(command -v colcon)" ]]; then \
     fi
 
 ############ run ###############################################################
-FROM dependencies-install as run
+FROM dependencies-install AS run
 
 # copy ROS install space from build stage
 COPY --from=build $WORKSPACE/install install

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -214,7 +214,14 @@ RUN source /opt/ros/$ROS_DISTRO/setup.bash && \
 ARG RMW_IMPLEMENTATION="rmw_cyclonedds_cpp"
 ENV RMW_IMPLEMENTATION=${RMW_IMPLEMENTATION}
 RUN source /opt/ros/$ROS_DISTRO/setup.bash && \
-    if [[ "$ROS_VERSION" == "2" ]]; then \
+    if [[ "$RMW_IMPLEMENTATION" == "rmw_zenoh" ]]; then \
+        git clone https://github.com/ros2/rmw_zenoh.git $WORKSPACE/src/upstream/rmw_zenoh && \
+        rosdep init || true && \
+        rosdep update --rosdistro $ROS_DISTRO && \
+        apt-get update && \
+        rosdep install -y --from-paths $WORKSPACE/src/upstream/rmw_zenoh --ignore-src --rosdistro $ROS_DISTRO && \
+        rm -rf /var/lib/apt/lists/* ; \
+    elif [[ "$ROS_VERSION" == "2" ]]; then \
         apt-get update && \
         RMW_PACKAGE=ros-$ROS_DISTRO-$(echo $RMW_IMPLEMENTATION | tr '_' '-') && \
         apt-get install -y $RMW_PACKAGE && \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -214,7 +214,7 @@ RUN source /opt/ros/$ROS_DISTRO/setup.bash && \
 ARG RMW_IMPLEMENTATION="rmw_cyclonedds_cpp"
 ENV RMW_IMPLEMENTATION=${RMW_IMPLEMENTATION}
 RUN source /opt/ros/$ROS_DISTRO/setup.bash && \
-    if [[ "$RMW_IMPLEMENTATION" == "rmw_zenoh" ]]; then \
+    if [[ "$RMW_IMPLEMENTATION" == "rmw_zenoh_cpp" ]]; then \
         git clone https://github.com/ros2/rmw_zenoh.git $WORKSPACE/src/upstream/rmw_zenoh && \
         rosdep init || true && \
         rosdep update --rosdistro $ROS_DISTRO && \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -215,17 +215,17 @@ ARG RMW_IMPLEMENTATION="rmw_cyclonedds_cpp"
 ENV RMW_IMPLEMENTATION=${RMW_IMPLEMENTATION}
 RUN source /opt/ros/$ROS_DISTRO/setup.bash && \
     if [[ "$RMW_IMPLEMENTATION" == "rmw_zenoh_cpp" ]]; then \
-        mkdir -p /opt/ws_rmw_zenoh/src && \
-        git clone https://github.com/ros2/rmw_zenoh.git /opt/ws_rmw_zenoh/src/rmw_zenoh && \
+        mkdir -p /tmp/ws_rmw_zenoh/src && \
+        git clone https://github.com/ros2/rmw_zenoh.git /tmp/ws_rmw_zenoh/src/ && \
         rosdep init || true && \
         rosdep update --rosdistro $ROS_DISTRO && \
         apt-get update && \
-        cd /opt/ws_rmw_zenoh && \
+        cd /tmp/ws_rmw_zenoh && \
         rosdep install -y --from-paths src --ignore-src --rosdistro $ROS_DISTRO && \
         rm -rf /var/lib/apt/lists/* && \
         source /opt/ros/${ROS_DISTRO}/setup.bash && \
-        colcon build --cmake-args -DCMAKE_BUILD_TYPE=Release && \
-        echo "source /opt/ws_rmw_zenoh/install/setup.bash" >> ~/.bashrc ; \
+        colcon build --install-base /opt/ros/${ROS_DISTRO}/ --merge-install --cmake-args -DCMAKE_BUILD_TYPE=Release && \
+        rm -rf /tmp/ws_rmw_zenoh ; \
     elif [[ "$ROS_VERSION" == "2" ]]; then \
         apt-get update && \
         RMW_PACKAGE=ros-$ROS_DISTRO-$(echo $RMW_IMPLEMENTATION | tr '_' '-') && \
@@ -257,7 +257,6 @@ FROM dev AS build
 # build ROS workspace
 RUN if [[ -x "$(command -v colcon)" ]]; then \
         source /opt/ros/${ROS_DISTRO}/setup.bash && \
-        [[ -f /opt/ws_rmw_zenoh/install/setup.bash ]] && source /opt/ws_rmw_zenoh/install/setup.bash ; \
         colcon build --cmake-args -DCMAKE_BUILD_TYPE=Release ; \
     elif [[ -x "$(command -v catkin)" ]]; then \
         catkin config --install --extend /opt/ros/${ROS_DISTRO} && \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -257,6 +257,7 @@ FROM dev AS build
 # build ROS workspace
 RUN if [[ -x "$(command -v colcon)" ]]; then \
         source /opt/ros/${ROS_DISTRO}/setup.bash && \
+        [[ -f /opt/ws_rmw_zenoh/install/setup.bash ]] && source /opt/ws_rmw_zenoh/install/setup.bash ; \
         colcon build --cmake-args -DCMAKE_BUILD_TYPE=Release ; \
     elif [[ -x "$(command -v catkin)" ]]; then \
         catkin config --install --extend /opt/ros/${ROS_DISTRO} && \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -215,17 +215,17 @@ ARG RMW_IMPLEMENTATION="rmw_cyclonedds_cpp"
 ENV RMW_IMPLEMENTATION=${RMW_IMPLEMENTATION}
 RUN source /opt/ros/$ROS_DISTRO/setup.bash && \
     if [[ "$RMW_IMPLEMENTATION" == "rmw_zenoh_cpp" ]]; then \
-        mkdir -p /tmp/ws_rmw_zenoh/src && \
-        git clone https://github.com/ros2/rmw_zenoh.git /tmp/ws_rmw_zenoh/src/ && \
+        mkdir -p /opt/ws_rmw_zenoh/src && \
+        git clone https://github.com/ros2/rmw_zenoh.git /opt/ws_rmw_zenoh/src/rmw_zenoh && \
         rosdep init || true && \
         rosdep update --rosdistro $ROS_DISTRO && \
         apt-get update && \
-        cd /tmp/ws_rmw_zenoh && \
+        cd /opt/ws_rmw_zenoh && \
         rosdep install -y --from-paths src --ignore-src --rosdistro $ROS_DISTRO && \
         rm -rf /var/lib/apt/lists/* && \
         source /opt/ros/${ROS_DISTRO}/setup.bash && \
-        colcon build --install-base /opt/ros/${ROS_DISTRO}/ --merge-install --cmake-args -DCMAKE_BUILD_TYPE=Release && \
-        rm -rf /tmp/ws_rmw_zenoh ; \
+        colcon build --cmake-args -DCMAKE_BUILD_TYPE=Release && \
+        echo "source /opt/ws_rmw_zenoh/install/setup.bash" >> ~/.bashrc ; \
     elif [[ "$ROS_VERSION" == "2" ]]; then \
         apt-get update && \
         RMW_PACKAGE=ros-$ROS_DISTRO-$(echo $RMW_IMPLEMENTATION | tr '_' '-') && \
@@ -257,6 +257,7 @@ FROM dev AS build
 # build ROS workspace
 RUN if [[ -x "$(command -v colcon)" ]]; then \
         source /opt/ros/${ROS_DISTRO}/setup.bash && \
+        [[ -f /opt/ws_rmw_zenoh/install/setup.bash ]] && source /opt/ws_rmw_zenoh/install/setup.bash ; \
         colcon build --cmake-args -DCMAKE_BUILD_TYPE=Release ; \
     elif [[ -x "$(command -v catkin)" ]]; then \
         catkin config --install --extend /opt/ros/${ROS_DISTRO} && \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -215,12 +215,17 @@ ARG RMW_IMPLEMENTATION="rmw_cyclonedds_cpp"
 ENV RMW_IMPLEMENTATION=${RMW_IMPLEMENTATION}
 RUN source /opt/ros/$ROS_DISTRO/setup.bash && \
     if [[ "$RMW_IMPLEMENTATION" == "rmw_zenoh_cpp" ]]; then \
-        git clone https://github.com/ros2/rmw_zenoh.git $WORKSPACE/src/upstream/rmw_zenoh && \
+        mkdir -p /opt/ws_rmw_zenoh/src && \
+        git clone https://github.com/ros2/rmw_zenoh.git /opt/ws_rmw_zenoh/src/rmw_zenoh && \
         rosdep init || true && \
         rosdep update --rosdistro $ROS_DISTRO && \
         apt-get update && \
-        rosdep install -y --from-paths $WORKSPACE/src/upstream/rmw_zenoh --ignore-src --rosdistro $ROS_DISTRO && \
-        rm -rf /var/lib/apt/lists/* ; \
+        cd /opt/ws_rmw_zenoh && \
+        rosdep install -y --from-paths src --ignore-src --rosdistro $ROS_DISTRO && \
+        rm -rf /var/lib/apt/lists/* && \
+        source /opt/ros/${ROS_DISTRO}/setup.bash && \
+        colcon build --cmake-args -DCMAKE_BUILD_TYPE=Release && \
+        echo "source /opt/ws_rmw_zenoh/install/setup.bash" >> ~/.bashrc ; \
     elif [[ "$ROS_VERSION" == "2" ]]; then \
         apt-get update && \
         RMW_PACKAGE=ros-$ROS_DISTRO-$(echo $RMW_IMPLEMENTATION | tr '_' '-') && \

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -3,6 +3,7 @@ set -e
 
 # source ROS workspace
 source /opt/ros/$ROS_DISTRO/setup.bash
+[[ -f /opt/ws_rmw_zenoh/install/setup.bash ]] && source /opt/ws_rmw_zenoh/install/setup.bash
 [[ -f $WORKSPACE/devel/setup.bash ]] && source $WORKSPACE/devel/setup.bash
 [[ -f $WORKSPACE/install/setup.bash ]] && source $WORKSPACE/install/setup.bash
 


### PR DESCRIPTION
- adds support for using `rmw_zenoh`
- only works for distros: `rolling`, `iron` and `jazzy` (restricted by zenoh)
- tested with simple talker / listener demo