### PR TITLE
Ignore RMW_IMPLEMENTATION for industrial_ci to avoid error if zenoh is used

### DIFF
--- a/.gitlab-ci/docker-ros.yml
+++ b/.gitlab-ci/docker-ros.yml
@@ -169,7 +169,6 @@ run-arm64:
 
 .test:
   variables:
-    UNDERLAY: /opt/ws_rmw_zenoh/install
     UPSTREAM_WORKSPACE: ${BUILD_CONTEXT}/.repos
     TARGET_WORKSPACE: ${BUILD_CONTEXT}
     ADDITIONAL_DEBS: git
@@ -184,6 +183,10 @@ run-arm64:
       fi
     - git clone --branch master --depth 1 https://github.com/ros-industrial/industrial_ci.git .industrial_ci
     - test -f ${BUILD_CONTEXT}/.repos || echo "repositories:" > ${BUILD_CONTEXT}/.repos
+    - |-
+      if [ "$RMW_IMPLEMENTATION" = "rmw_zenoh_cpp" ]; then
+        export UNDERLAY="/opt/ws_rmw_zenoh/install"
+      fi
   script: .industrial_ci/gitlab.sh
 
 Test dev-amd64:

--- a/.gitlab-ci/docker-ros.yml
+++ b/.gitlab-ci/docker-ros.yml
@@ -169,7 +169,7 @@ run-arm64:
 
 .test:
   variables:
-    RMW_IMPLEMENTATION: rmw_cyclonedds_cpp # avoid missing rmw_zenoh_cpp errors, if used
+    UNDERLAY: /opt/ws_rmw_zenoh/install
     UPSTREAM_WORKSPACE: ${BUILD_CONTEXT}/.repos
     TARGET_WORKSPACE: ${BUILD_CONTEXT}
     ADDITIONAL_DEBS: git

--- a/.gitlab-ci/docker-ros.yml
+++ b/.gitlab-ci/docker-ros.yml
@@ -169,6 +169,7 @@ run-arm64:
 
 .test:
   variables:
+    RMW_IMPLEMENTATION: rmw_cyclonedds_cpp # avoid missing rmw_zenoh_cpp errors, if used
     UPSTREAM_WORKSPACE: ${BUILD_CONTEXT}/.repos
     TARGET_WORKSPACE: ${BUILD_CONTEXT}
     ADDITIONAL_DEBS: git

--- a/action.yml
+++ b/action.yml
@@ -226,6 +226,7 @@ runs:
       if: ${{ inputs.enable-industrial-ci == 'true' }}
       uses: ros-industrial/industrial_ci@master
       env:
+        RMW_IMPLEMENTATION: rmw_cyclonedds_cpp # avoid missing rmw_zenoh_cpp errors, if used
         UPSTREAM_WORKSPACE: ${{ inputs.build-context }}/.repos
         TARGET_WORKSPACE: ${{ inputs.build-context }}
         ADDITIONAL_DEBS: git

--- a/action.yml
+++ b/action.yml
@@ -226,11 +226,10 @@ runs:
       if: ${{ inputs.enable-industrial-ci == 'true' }}
       uses: ros-industrial/industrial_ci@master
       env:
-        UNDERLAY: /opt/ws_rmw_zenoh/install
         UPSTREAM_WORKSPACE: ${{ inputs.build-context }}/.repos
         TARGET_WORKSPACE: ${{ inputs.build-context }}
         ADDITIONAL_DEBS: git
-        AFTER_INIT_EMBED: '[[ -n ${{ inputs.git-https-server }} ]] && git config --global url.https://${{ inputs.git-https-user }}:${{ inputs.git-https-password }}@${{ inputs.git-https-server }}.insteadOf https://${{ inputs.git-https-server }}'
+        AFTER_INIT_EMBED: '[[ "$RMW_IMPLEMENTATION" == "rmw_zenoh_cpp" ]] && export UNDERLAY="/opt/ws_rmw_zenoh/install" ; [[ -n ${{ inputs.git-https-server }} ]] && git config --global url.https://${{ inputs.git-https-user }}:${{ inputs.git-https-password }}@${{ inputs.git-https-server }}.insteadOf https://${{ inputs.git-https-server }}'
         SSH_PRIVATE_KEY: ${{ inputs.git-ssh-private-key }}
         SSH_SERVER_HOSTKEYS: ${{ inputs.git-ssh-known-host-keys }}
         DOCKER_RUN_OPTS: -u root:root

--- a/action.yml
+++ b/action.yml
@@ -226,7 +226,7 @@ runs:
       if: ${{ inputs.enable-industrial-ci == 'true' }}
       uses: ros-industrial/industrial_ci@master
       env:
-        RMW_IMPLEMENTATION: rmw_cyclonedds_cpp # avoid missing rmw_zenoh_cpp errors, if used
+        UNDERLAY: /opt/ws_rmw_zenoh/install
         UPSTREAM_WORKSPACE: ${{ inputs.build-context }}/.repos
         TARGET_WORKSPACE: ${{ inputs.build-context }}
         ADDITIONAL_DEBS: git


### PR DESCRIPTION
Hotfix after https://github.com/ika-rwth-aachen/docker-ros/pull/34