### PR TITLE
Fix slim integration for multiarch builds in GitHub CI

### DIFF
--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -96,14 +96,12 @@ for PLATFORM in "${PLATFORMS[@]}"; do
         [[ -n "${_IMAGE_POSTFIX}" ]] && slim_image="${slim_image}${_IMAGE_POSTFIX}"
         [[ "${_ENABLE_IMAGE_PUSH}" != "true" || "${ENABLE_SINGLEARCH_PUSH}" == "true" ]] && image="${image}-${PLATFORM}"
         [[ "${_ENABLE_IMAGE_PUSH}" != "true" || "${ENABLE_SINGLEARCH_PUSH}" == "true" ]] && slim_image="${slim_image}-${PLATFORM}"
-        if [[ "${_ENABLE_IMAGE_PUSH}" == "true" || "${ENABLE_SINGLEARCH_PUSH}" == "true" ]]; then
-            [[ "${ENABLE_SINGLEARCH_PUSH}" != "true" ]] && docker tag "${slim_image}-${PLATFORM}" "${slim_image}"
+        cd dist_linux*
+        ./slim build --target "${image}" --tag "${slim_image}" ${SLIM_BUILD_ARGS}
+        if [[ "${_ENABLE_IMAGE_PUSH}" == "true" ]]; then
             docker push "${slim_image}"
-        else
-            cd dist_linux*
-            ./slim build --target "${image}" --tag "${slim_image}" ${SLIM_BUILD_ARGS}
-            cd -
         fi
+        cd -
         close_log_group
     fi
 done


### PR DESCRIPTION
- #33 has integrated built-in support for slim. A hotfix is required to run slim in GitHub jobs that build multiarch images, i.e., `platforms: amd64,arm64` and `enable-singlearch-push: false`.
- Currently, the lines responsible for pushing the slimmed image cannot handle multiarch-tags, see [this mqtt_client action log](https://github.com/ika-rwth-aachen/mqtt_client/actions/runs/11554064275).
- The fix is to re-run slim in the second `push` execution of `ci.sh`, where platforms are not treated separately anymore. A current shortcoming is that slim is then only executed for the native platform, i.e., `amd64` in most cases. You would end up with `latest` (multiarch) and `latest-slim` (singlearch).
- A successful [mqtt_client action log is found here](https://github.com/ika-rwth-aachen/mqtt_client/actions/runs/11554990453/job/32159380912).