### PR TITLE
Fix workspace such that docker-ros-generated images can be used as base images for docker-ros

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ jobs:
   docker-ros:
     runs-on: ubuntu-latest
     steps:
-      - uses: ika-rwth-aachen/docker-ros@v1.6.1
+      - uses: ika-rwth-aachen/docker-ros@v1.6.2
         with:
           base-image: rwthika/ros2:humble
           command: ros2 run my_pkg my_node
@@ -124,7 +124,7 @@ jobs:
 
 ```yml
 include:
-  - remote: https://raw.githubusercontent.com/ika-rwth-aachen/docker-ros/v1.6.1/.gitlab-ci/docker-ros.yml
+  - remote: https://raw.githubusercontent.com/ika-rwth-aachen/docker-ros/v1.6.2/.gitlab-ci/docker-ros.yml
 
 variables:
   BASE_IMAGE: rwthika/ros2:humble
@@ -143,7 +143,7 @@ jobs:
   docker-ros:
     runs-on: ubuntu-latest
     steps:
-      - uses: ika-rwth-aachen/docker-ros@v1.6.1
+      - uses: ika-rwth-aachen/docker-ros@v1.6.2
         with:
           base-image: rwthika/ros2:humble
           command: ros2 run my_pkg my_node
@@ -156,7 +156,7 @@ jobs:
 
 ```yml
 include:
-  - remote: https://raw.githubusercontent.com/ika-rwth-aachen/docker-ros/v1.6.1/.gitlab-ci/docker-ros.yml
+  - remote: https://raw.githubusercontent.com/ika-rwth-aachen/docker-ros/v1.6.2/.gitlab-ci/docker-ros.yml
 
 variables:
   BASE_IMAGE: rwthika/ros2:humble
@@ -176,7 +176,7 @@ jobs:
   docker-ros:
     runs-on: ubuntu-latest
     steps:
-      - uses: ika-rwth-aachen/docker-ros@v1.6.1
+      - uses: ika-rwth-aachen/docker-ros@v1.6.2
         with:
           base-image: rwthika/ros2:humble
           command: ros2 run my_pkg my_node
@@ -190,7 +190,7 @@ jobs:
 
 ```yml
 include:
-  - remote: https://raw.githubusercontent.com/ika-rwth-aachen/docker-ros/v1.6.1/.gitlab-ci/docker-ros.yml
+  - remote: https://raw.githubusercontent.com/ika-rwth-aachen/docker-ros/v1.6.2/.gitlab-ci/docker-ros.yml
 
 variables:
   BASE_IMAGE: rwthika/ros2:humble
@@ -211,7 +211,7 @@ jobs:
   docker-ros:
     runs-on: ubuntu-latest
     steps:
-      - uses: ika-rwth-aachen/docker-ros@v1.6.1
+      - uses: ika-rwth-aachen/docker-ros@v1.6.2
         with:
           base-image: rwthika/ros2:humble
           command: ros2 run my_pkg my_node
@@ -224,7 +224,7 @@ jobs:
 
 ```yml
 include:
-  - remote: https://raw.githubusercontent.com/ika-rwth-aachen/docker-ros/v1.6.1/.gitlab-ci/docker-ros.yml
+  - remote: https://raw.githubusercontent.com/ika-rwth-aachen/docker-ros/v1.6.2/.gitlab-ci/docker-ros.yml
 
 variables:
   BASE_IMAGE: rwthika/ros2:humble
@@ -248,7 +248,7 @@ jobs:
         platform: [amd64, arm64]
     runs-on: [self-hosted, "${{ matrix.platform }}"]
     steps:
-      - uses: ika-rwth-aachen/docker-ros@v1.6.1
+      - uses: ika-rwth-aachen/docker-ros@v1.6.2
         with:
           base-image: rwthika/ros2:humble
           command: ros2 run my_pkg my_node

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -245,7 +245,7 @@ RUN source /opt/ros/$ROS_DISTRO/setup.bash && \
         rm -rf /var/lib/apt/lists/* ; \
     fi
 
-# create new install space and move to it if $WORKSPACE/install exists
+# move existing install space from base image to make room for new one
 RUN if [[ -d $WORKSPACE/install ]]; then \
         mkdir -p /opt/ws_base_image && \
         mv $WORKSPACE/install /opt/ws_base_image/ && \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -86,7 +86,7 @@ RUN echo "colcon list -p --base-paths src/ --packages-select \\" >> $WORKSPACE/.
     $WORKSPACE/.remove-packages.sh 2> /dev/null | xargs rm -rf
 
 # create install script with list of rosdep dependencies
-RUN echo "set -e" >> $WORKSPACE/.install-dependencies.sh && \
+RUN echo "set -e" > $WORKSPACE/.install-dependencies.sh && \
     source /opt/ros/$ROS_DISTRO/setup.bash && \
     apt-get update && \
     rosdep init || true && \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -276,6 +276,9 @@ RUN if [[ -x "$(command -v colcon)" ]]; then \
 ############ run ###############################################################
 FROM dependencies-install AS run
 
+# remove source folder
+RUN rm -rf $WORKSPACE/src
+
 # copy ROS install space from build stage
 COPY --from=build $WORKSPACE/install install
 RUN ldconfig

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -274,6 +274,7 @@ FROM dev AS build
 RUN if [[ -x "$(command -v colcon)" ]]; then \
         source /opt/ros/${ROS_DISTRO}/setup.bash && \
         [[ -f /opt/ws_rmw_zenoh/install/setup.bash ]] && source /opt/ws_rmw_zenoh/install/setup.bash ; \
+        [[ -f /opt/ws_base_image/install/setup.bash ]] && source /opt/ws_base_image/install/setup.bash ; \
         colcon build --cmake-args -DCMAKE_BUILD_TYPE=Release ; \
     elif [[ -x "$(command -v catkin)" ]]; then \
         catkin config --install --extend /opt/ros/${ROS_DISTRO} && \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -161,13 +161,6 @@ ENV WORKSPACE=/docker-ros/ws
 ENV COLCON_HOME=$WORKSPACE/.colcon
 WORKDIR $WORKSPACE
 
-# create new install space and move to it if $WORKSPACE/install exists
-RUN if [[ -d $WORKSPACE/install ]]; then \
-        mkdir -p /opt/ws_base_image && \
-        mv $WORKSPACE/install /opt/ws_base_image/ && \
-        echo "source /opt/ws_base_image/install/setup.bash" >> ~/.bashrc ; \
-    fi
-
 # setup keys and sources.list for ROS packages
 ARG ROS_DISTRO
 ENV ROS_DISTRO=${ROS_DISTRO}
@@ -223,6 +216,9 @@ RUN source /opt/ros/$ROS_DISTRO/setup.bash && \
     fi \
     && rm -rf /var/lib/apt/lists/*
 
+# source ROS
+RUN echo "source /opt/ros/$ROS_DISTRO/setup.bash" >> ~/.bashrc
+
 # install desired ROS 2 middleware
 ARG RMW_IMPLEMENTATION="rmw_cyclonedds_cpp"
 ENV RMW_IMPLEMENTATION=${RMW_IMPLEMENTATION}
@@ -249,8 +245,12 @@ RUN source /opt/ros/$ROS_DISTRO/setup.bash && \
         rm -rf /var/lib/apt/lists/* ; \
     fi
 
-# source ROS
-RUN echo "source /opt/ros/$ROS_DISTRO/setup.bash" >> ~/.bashrc
+# create new install space and move to it if $WORKSPACE/install exists
+RUN if [[ -d $WORKSPACE/install ]]; then \
+        mkdir -p /opt/ws_base_image && \
+        mv $WORKSPACE/install /opt/ws_base_image/ && \
+        echo "source /opt/ws_base_image/install/setup.bash" >> ~/.bashrc ; \
+    fi
 
 # set entrypoint
 ENV TINI_VERSION=v0.19.0

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -283,7 +283,7 @@ RUN if [[ -x "$(command -v colcon)" ]]; then \
 ############ run ###############################################################
 FROM dependencies-install AS run
 
-# remove source folder
+# remove source code, if still existing from custom.sh modifications
 RUN rm -rf $WORKSPACE/src
 
 # copy ROS install space from build stage

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -161,6 +161,13 @@ ENV WORKSPACE=/docker-ros/ws
 ENV COLCON_HOME=$WORKSPACE/.colcon
 WORKDIR $WORKSPACE
 
+# create new workspace if $WORKSPACE/install exists
+RUN if [[ -d $WORKSPACE/install ]]; then \
+        mkdir -p /opt/ws_base_image && \
+        mv $WORKSPACE/install /opt/ws_base_image/ && \
+        echo "source /opt/ws_base_image/install/setup.bash" >> ~/.bashrc ; \
+    fi
+
 # setup keys and sources.list for ROS packages
 ARG ROS_DISTRO
 ENV ROS_DISTRO=${ROS_DISTRO}

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -161,7 +161,7 @@ ENV WORKSPACE=/docker-ros/ws
 ENV COLCON_HOME=$WORKSPACE/.colcon
 WORKDIR $WORKSPACE
 
-# create new workspace if $WORKSPACE/install exists
+# create new install space and move to it if $WORKSPACE/install exists
 RUN if [[ -d $WORKSPACE/install ]]; then \
         mkdir -p /opt/ws_base_image && \
         mv $WORKSPACE/install /opt/ws_base_image/ && \

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -4,6 +4,7 @@ set -e
 # source ROS workspace
 source /opt/ros/$ROS_DISTRO/setup.bash
 [[ -f /opt/ws_rmw_zenoh/install/setup.bash ]] && source /opt/ws_rmw_zenoh/install/setup.bash
+[[ -f /opt/ws_base_image/install/setup.bash ]] && source /opt/ws_base_image/install/setup.bash
 [[ -f $WORKSPACE/devel/setup.bash ]] && source $WORKSPACE/devel/setup.bash
 [[ -f $WORKSPACE/install/setup.bash ]] && source $WORKSPACE/install/setup.bash
 


### PR DESCRIPTION
The following modifications are necessary to enable the usage of docker-ros-generated images, which already have their install space and their src folder, as base images for docker-ros:
- Create new bash script .install-dependencies.sh for a newly started pipeline run instead of appending an existing one. 
- If the install space already exists in the scope of the base image (docker-ros-generated), move this install space in order to make space for a new one.
- Remove potentially existing src folder which might exist in the scope for the base image (docker-ros-generated).
- Source from both, from the moved install space coming from the base image (docker-ros-generated) and from the newly created install space.