### PR TITLE
Update buildkit image source

### DIFF
--- a/.gitlab-ci/docker-ros.yml
+++ b/.gitlab-ci/docker-ros.yml
@@ -112,7 +112,7 @@ default:
       fi
     - docker login -u ${REGISTRY_USER} -p ${REGISTRY_PASSWORD} ${REGISTRY}
     - docker context create buildx-context
-    - docker buildx create --use buildx-context
+    - docker buildx create --use --driver docker-container --driver-opt image=public.ecr.aws/vend/moby/buildkit:buildx-stable-1
     - echo -e "section_end:`date +%s`:setup_section\r\e[0K"
 
 .build:

--- a/.gitlab-ci/docker-ros.yml
+++ b/.gitlab-ci/docker-ros.yml
@@ -112,7 +112,7 @@ default:
       fi
     - docker login -u ${REGISTRY_USER} -p ${REGISTRY_PASSWORD} ${REGISTRY}
     - docker context create buildx-context
-    - docker buildx create --use --driver docker-container --driver-opt image=public.ecr.aws/vend/moby/buildkit:buildx-stable-1
+    - docker buildx create --use buildx-context --driver docker-container --driver-opt image=public.ecr.aws/vend/moby/buildkit:buildx-stable-1
     - echo -e "section_end:`date +%s`:setup_section\r\e[0K"
 
 .build:

--- a/action.yml
+++ b/action.yml
@@ -158,6 +158,10 @@ runs:
 
     - name: Set up Docker buildx
       uses: docker/setup-buildx-action@v3
+      with:
+        driver: docker-container
+        driver-opts: |
+          image=public.ecr.aws/vend/moby/buildkit:buildx-stable-1
 
     - name: Enforce lower-case image name 
       id: image-name


### PR DESCRIPTION
Changes the image surce of the buildkit from [moby/buildkit:buildx-stable-1](
https://hub.docker.com/r/moby/buildkit) to [public.ecr.aws/vend/moby/buildkit:buildx-stable-1](https://gallery.ecr.aws/vend/moby/buildkit).

> Anyone who pulls images anonymously [from https://gallery.ecr.aws] will get 500 GB of free data bandwidth each month

https://aws.amazon.com/blogs/aws/amazon-ecr-public-a-new-public-container-registry/