### PR TITLE
Update default `rmw-zenoh-git-ref`

### DIFF
--- a/.gitlab-ci/docker-ros.yml
+++ b/.gitlab-ci/docker-ros.yml
@@ -40,7 +40,7 @@ variables:
   REGISTRY_USER:              ${CI_REGISTRY_USER}                     # Docker registry username
   REGISTRY:                   ${CI_REGISTRY}                          # Docker registry to push images to
   RMW_IMPLEMENTATION:         'rmw_cyclonedds_cpp'                    # RMW implementation to use (only for ROS 2)
-  RMW_ZENOH_GIT_REF:          '28d917e0532fed6e9703f044662298f2b3553716'  # Git ref of rmw_zenoh repo to build if `RMW_IMPLEMENTATION=rmw_zenoh_cpp`
+  RMW_ZENOH_GIT_REF:          'a7187eb42fd6a6a6bdfacf4308add39e5d8a27c7'  # Git ref of rmw_zenoh repo to build if `RMW_IMPLEMENTATION=rmw_zenoh_cpp`
   ROS_DISTRO:                 ''                                      # ROS Distro (required if ROS is not installed in `base-image`)
   SLIM_BUILD_ARGS:            '--sensor-ipc-mode proxy --continue-after=10 --show-clogs --http-probe=false'  # Arguments to `slim build` (except for `--target` and `--tag`)
   TARGET:                     run                                     # Target stage of Dockerfile (comma-separated list) [dev|run]

--- a/README.md
+++ b/README.md
@@ -468,7 +468,7 @@ The password of the custom user is set to its username (`dockeruser:dockeruser` 
   *supported values:* `rmw_zenoh_cpp`, `rmw_fastrtps_cpp`, `rmw_cyclonedds_cpp`, `rmw_gurumdds_cpp`, ...  
 - **`rmw-zenoh-git-ref` | `RMW_ZENOH_GIT_REF`**  
   Git ref of rmw_zenoh repo to build if `RMW_IMPLEMENTATION=rmw_zenoh_cpp`  
-  *default:* `28d917e0532fed6e9703f044662298f2b3553716`  
+  *default:* `a7187eb42fd6a6a6bdfacf4308add39e5d8a27c7`  
 - **`ros-distro` | `ROS_DISTRO`**  
   ROS Distro  
   *required if ROS is not installed in `base-image`*  

--- a/action.yml
+++ b/action.yml
@@ -106,7 +106,7 @@ inputs:
     default: rmw_cyclonedds_cpp
   rmw-zenoh-git-ref:
     description: "Git ref of rmw_zenoh repo to build if `RMW_IMPLEMENTATION=rmw_zenoh_cpp`"
-    default: 28d917e0532fed6e9703f044662298f2b3553716
+    default: a7187eb42fd6a6a6bdfacf4308add39e5d8a27c7
   slim-build-args:
     description: "Arguments to `slim build` (except for `--target` and `--tag`)"
     default: '--sensor-ipc-mode proxy --continue-after=10 --show-clogs --http-probe=false'

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -89,7 +89,7 @@ RUN echo "colcon list -p --base-paths src/ --packages-select \\" >> $WORKSPACE/.
 RUN echo "set -e" > $WORKSPACE/.install-dependencies.sh && \
     source /opt/ros/$ROS_DISTRO/setup.bash && \
     apt-get update && \
-    rosdep init || true && \
+    (rosdep init || true) && \
     rosdep update --rosdistro ${ROS_DISTRO} && \
     export OS="ubuntu:$(lsb_release -c | awk '{print $2}')" && \
     if [[ "$ROS_DISTRO" = "rolling" && "$OS" = "ubuntu:focal" ]]; then export OS="ubuntu:jammy"; fi && \
@@ -233,7 +233,7 @@ RUN source /opt/ros/$ROS_DISTRO/setup.bash && \
         if [[ "$(lsb_release -r | awk '{print $2}')" == "22.04" ]]; then \
             git clone -b 2.2.x https://github.com/eProsima/Fast-CDR.git /opt/ws_rmw_zenoh/src/Fast-CDR ; \
         fi && \
-        rosdep init || true && \
+        (rosdep init || true) && \
         rosdep update --rosdistro $ROS_DISTRO && \
         apt-get update && \
         cd /opt/ws_rmw_zenoh && \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -222,7 +222,7 @@ RUN echo "source /opt/ros/$ROS_DISTRO/setup.bash" >> ~/.bashrc
 # install desired ROS 2 middleware
 ARG RMW_IMPLEMENTATION="rmw_cyclonedds_cpp"
 ENV RMW_IMPLEMENTATION=${RMW_IMPLEMENTATION}
-ARG RMW_ZENOH_GIT_REF="28d917e0532fed6e9703f044662298f2b3553716"
+ARG RMW_ZENOH_GIT_REF="a7187eb42fd6a6a6bdfacf4308add39e5d8a27c7"
 RUN source /opt/ros/$ROS_DISTRO/setup.bash && \
     if [[ "$RMW_IMPLEMENTATION" == "rmw_zenoh_cpp" ]]; then \
         mkdir -p /opt/ws_rmw_zenoh/src && \


### PR DESCRIPTION
- set default `rmw-zenoh-git-ref` to https://github.com/ros2/rmw_zenoh/commit/a7187eb42fd6a6a6bdfacf4308add39e5d8a27c7
- the previous default (https://github.com/ros2/rmw_zenoh/commit/28d917e0532fed6e9703f044662298f2b3553716) does no longer belong to any branch (seems to be foce-pushed)
- in addition, the behavior of `rosdep update || true` is fixed / improved