### PR TITLE
Defaultly use latest distro branch as zenoh ref

### DIFF
--- a/.gitlab-ci/docker-ros.yml
+++ b/.gitlab-ci/docker-ros.yml
@@ -40,7 +40,7 @@ variables:
   REGISTRY_USER:              ${CI_REGISTRY_USER}                     # Docker registry username
   REGISTRY:                   ${CI_REGISTRY}                          # Docker registry to push images to
   RMW_IMPLEMENTATION:         'rmw_cyclonedds_cpp'                    # RMW implementation to use (only for ROS 2)
-  RMW_ZENOH_GIT_REF:          'a7187eb42fd6a6a6bdfacf4308add39e5d8a27c7'  # Git ref of rmw_zenoh repo to build if `RMW_IMPLEMENTATION=rmw_zenoh_cpp`
+  RMW_ZENOH_GIT_REF:          ''                                      # Git ref of rmw_zenoh repo to build if `RMW_IMPLEMENTATION=rmw_zenoh_cpp`
   ROS_DISTRO:                 ''                                      # ROS Distro (required if ROS is not installed in `base-image`)
   SLIM_BUILD_ARGS:            '--sensor-ipc-mode proxy --continue-after=10 --show-clogs --http-probe=false'  # Arguments to `slim build` (except for `--target` and `--tag`)
   TARGET:                     run                                     # Target stage of Dockerfile (comma-separated list) [dev|run]

--- a/README.md
+++ b/README.md
@@ -468,7 +468,7 @@ The password of the custom user is set to its username (`dockeruser:dockeruser` 
   *supported values:* `rmw_zenoh_cpp`, `rmw_fastrtps_cpp`, `rmw_cyclonedds_cpp`, `rmw_gurumdds_cpp`, ...  
 - **`rmw-zenoh-git-ref` | `RMW_ZENOH_GIT_REF`**  
   Git ref of rmw_zenoh repo to build if `RMW_IMPLEMENTATION=rmw_zenoh_cpp`  
-  *default:* `` (latest distro branch)  
+  *default:* `$ROS_DISTRO`  
 - **`ros-distro` | `ROS_DISTRO`**  
   ROS Distro  
   *required if ROS is not installed in `base-image`*  

--- a/README.md
+++ b/README.md
@@ -468,7 +468,7 @@ The password of the custom user is set to its username (`dockeruser:dockeruser` 
   *supported values:* `rmw_zenoh_cpp`, `rmw_fastrtps_cpp`, `rmw_cyclonedds_cpp`, `rmw_gurumdds_cpp`, ...  
 - **`rmw-zenoh-git-ref` | `RMW_ZENOH_GIT_REF`**  
   Git ref of rmw_zenoh repo to build if `RMW_IMPLEMENTATION=rmw_zenoh_cpp`  
-  *default:* `a7187eb42fd6a6a6bdfacf4308add39e5d8a27c7`  
+  *default:* `` (latest distro branch)  
 - **`ros-distro` | `ROS_DISTRO`**  
   ROS Distro  
   *required if ROS is not installed in `base-image`*  

--- a/action.yml
+++ b/action.yml
@@ -106,7 +106,6 @@ inputs:
     default: rmw_cyclonedds_cpp
   rmw-zenoh-git-ref:
     description: "Git ref of rmw_zenoh repo to build if `RMW_IMPLEMENTATION=rmw_zenoh_cpp`"
-    default: a7187eb42fd6a6a6bdfacf4308add39e5d8a27c7
   slim-build-args:
     description: "Arguments to `slim build` (except for `--target` and `--tag`)"
     default: '--sensor-ipc-mode proxy --continue-after=10 --show-clogs --http-probe=false'

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -222,14 +222,14 @@ RUN echo "source /opt/ros/$ROS_DISTRO/setup.bash" >> ~/.bashrc
 # install desired ROS 2 middleware
 ARG RMW_IMPLEMENTATION
 ENV RMW_IMPLEMENTATION=${RMW_IMPLEMENTATION:-rmw_cyclonedds_cpp}
-ARG RMW_ZENOH_GIT_REF="a7187eb42fd6a6a6bdfacf4308add39e5d8a27c7"
+ARG RMW_ZENOH_GIT_REF
 RUN source /opt/ros/$ROS_DISTRO/setup.bash && \
     if [[ "$RMW_IMPLEMENTATION" == "rmw_zenoh_cpp" ]]; then \
         if [[ ! -d /opt/ws_rmw_zenoh/src ]]; then \
             mkdir -p /opt/ws_rmw_zenoh/src && \
             git clone https://github.com/ros2/rmw_zenoh.git /opt/ws_rmw_zenoh/src/rmw_zenoh && \
             cd /opt/ws_rmw_zenoh/src/rmw_zenoh && \
-            git checkout ${RMW_ZENOH_GIT_REF} && \
+            git checkout ${RMW_ZENOH_GIT_REF:-${ROS_DISTRO}} && \
             cd - && \
             if [[ "$(lsb_release -r | awk '{print $2}')" == "22.04" ]]; then \
                 git clone -b 2.2.x https://github.com/eProsima/Fast-CDR.git /opt/ws_rmw_zenoh/src/Fast-CDR ; \


### PR DESCRIPTION
In the [rmw_zenoh repo](https://github.com/ros2/rmw_zenoh), the separation between rolling / humble and jazzy has been made. Using the latest version of each branch fixes errors that still occur. E.g. timestamps in bag files.

Once zenoh is available on apt, the build-from-src should be discarded (but: think about jazzy ubuntu22 images).