### PR TITLE
Change RMW default to rmw_fastrtps_cpp

### DIFF
--- a/.gitlab-ci/docker-ros.yml
+++ b/.gitlab-ci/docker-ros.yml
@@ -40,7 +40,7 @@ variables:
   REGISTRY_PASSWORD:          ${CI_REGISTRY_PASSWORD}                 # Docker registry password
   REGISTRY_USER:              ${CI_REGISTRY_USER}                     # Docker registry username
   REGISTRY:                   ${CI_REGISTRY}                          # Docker registry to push images to
-  RMW_IMPLEMENTATION:         'rmw_cyclonedds_cpp'                    # RMW implementation to use (only for ROS 2)
+  RMW_IMPLEMENTATION:         'rmw_fastrtps_cpp'                      # RMW implementation to use (only for ROS 2)
   ROS_DISTRO:                 ''                                      # ROS Distro (required if ROS is not installed in `base-image`)
   SLIM_BUILD_ARGS:            '--sensor-ipc-mode proxy --continue-after=10 --show-clogs --http-probe=false'  # Arguments to `slim build` (except for `--target` and `--tag`)
   TARGET:                     run                                     # Target stage of Dockerfile (comma-separated list) [dev|run]

--- a/README.md
+++ b/README.md
@@ -467,7 +467,7 @@ The password of the custom user is set to its username (`dockeruser:dockeruser` 
   *default:* `${{ github.actor }}` | `$CI_REGISTRY_USER`  
 - **`rmw-implementation` | `RMW_IMPLEMENTATION`**  
   ROS 2 middleware implementation  
-  *default:* `rmw_cyclonedds_cpp`  
+  *default:* `rmw_fastrtps_cpp`  
   *supported values:* `rmw_zenoh_cpp`, `rmw_fastrtps_cpp`, `rmw_cyclonedds_cpp`, `rmw_gurumdds_cpp`, ...  
 - **`ros-distro` | `ROS_DISTRO`**  
   ROS Distro  

--- a/action.yml
+++ b/action.yml
@@ -106,7 +106,7 @@ inputs:
     description: "ROS Distro (required if ROS is not installed in `base-image`)"
   rmw-implementation:
     description: "RMW implementation to use (only for ROS 2)"
-    default: rmw_cyclonedds_cpp
+    default: rmw_fastrtps_cpp
   slim-build-args:
     description: "Arguments to `slim build` (except for `--target` and `--tag`)"
     default: '--sensor-ipc-mode proxy --continue-after=10 --show-clogs --http-probe=false'

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -221,7 +221,7 @@ RUN echo "source /opt/ros/$ROS_DISTRO/setup.bash" >> ~/.bashrc
 
 # install desired ROS 2 middleware
 ARG RMW_IMPLEMENTATION
-ENV RMW_IMPLEMENTATION=${RMW_IMPLEMENTATION:-rmw_cyclonedds_cpp}
+ENV RMW_IMPLEMENTATION=${RMW_IMPLEMENTATION:-rmw_fastrtps_cpp}
 RUN source /opt/ros/$ROS_DISTRO/setup.bash && \
     if [[ "$ROS_VERSION" == "2" && "$DISABLE_ROS_INSTALLATION" != "true" ]]; then \
         apt-get update && \


### PR DESCRIPTION
- switch default of `RMW_IMPLEMENTATION` back to `rmw_fastrtps_cpp`
- reason is that FastRTPS is still the ROS 2 default DDS implementation
- related to https://github.com/ika-rwth-aachen/docker-ros/pull/19