### PR TITLE
Allow rosdep to break system packages for pip dependencies

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -94,7 +94,7 @@ RUN echo "set -e" > $WORKSPACE/.install-dependencies.sh && \
     export OS="ubuntu:$(lsb_release -c | awk '{print $2}')" && \
     if [[ "$ROS_DISTRO" = "rolling" && "$OS" = "ubuntu:focal" ]]; then export OS="ubuntu:jammy"; fi && \
     set -o pipefail && \
-    ROS_PACKAGE_PATH=$(pwd):$ROS_PACKAGE_PATH rosdep install --os $OS -y --simulate --from-paths src --ignore-src \
+    PIP_BREAK_SYSTEM_PACKAGES=1 ROS_PACKAGE_PATH=$(pwd):$ROS_PACKAGE_PATH rosdep install --os $OS -y --simulate --from-paths src --ignore-src \
     | sed -E "s/'apt-get install -y ([^']+)' \(alternative 1\/1\)/apt-get install -y \1/" \
     | tee -a $WORKSPACE/.install-dependencies.sh && \
     chmod +x $WORKSPACE/.install-dependencies.sh && \


### PR DESCRIPTION
- add `PIP_BREAK_SYSTEM_PACKAGES=1` to rosdep command