### PR TITLE
fixing errors when adding comment lines in additional installs

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -88,7 +88,7 @@ RUN echo "colcon list -p --base-paths src/ --packages-select \\" >> $WORKSPACE/.
     if [[ $ENABLE_RECURSIVE_BLACKLISTED_PACKAGES == 'true' ]]; then \
         find . -type f -name $(basename ${BLACKLISTED_PACKAGES_FILE}) -exec sed '$a\' {} \; | awk '{print "  " $0 " \\"}' >> $WORKSPACE/.remove-packages.sh ; \
     elif [[ -f src/target/${BLACKLISTED_PACKAGES_FILE} ]]; then \
-        cat src/target/${BLACKLISTED_PACKAGES_FILE} | awk '!/^#/ {print "  " $0 " \\"}' >> $WORKSPACE/.remove-packages.sh ; \
+        cat src/target/${BLACKLISTED_PACKAGES_FILE} | awk '{ gsub(/#.*/, ""); gsub(/^[ \t]+|[ \t]+$/, ""); if (NF) print "  " $0 " \\" }' >> $WORKSPACE/.remove-packages.sh ; \
     fi && \
     echo ";" >> $WORKSPACE/.remove-packages.sh && \
     chmod +x $WORKSPACE/.remove-packages.sh && \
@@ -129,7 +129,7 @@ RUN echo "apt-get install -y \\" >> $WORKSPACE/.install-dependencies.sh && \
     if [[ $ENABLE_RECURSIVE_ADDITIONAL_DEBS == 'true' ]]; then \
         find . -type f -name $(basename ${ADDITIONAL_DEBS_FILE}) -exec sed '$a\' {} \; | awk '{print "  " $0 " \\"}' >> $WORKSPACE/.install-dependencies.sh ; \
     elif [[ -f src/target/${ADDITIONAL_DEBS_FILE} ]]; then \
-        cat src/target/${ADDITIONAL_DEBS_FILE} | awk '!/^#/ {print "  " $0 " \\"}' >> $WORKSPACE/.install-dependencies.sh ; \
+        cat src/target/${ADDITIONAL_DEBS_FILE} | awk '{ gsub(/#.*/, ""); gsub(/^[ \t]+|[ \t]+$/, ""); if (NF) print "  " $0 " \\" }' >> $WORKSPACE/.install-dependencies.sh ; \
     fi && \
     echo ";" >> $WORKSPACE/.install-dependencies.sh
 
@@ -141,7 +141,7 @@ RUN echo "pip install pip \\" >> $WORKSPACE/.install-dependencies.sh && \
     if [[ $ENABLE_RECURSIVE_ADDITIONAL_PIP == 'true' ]]; then \
         find . -type f -name $(basename ${ADDITIONAL_PIP_FILE}) -exec sed '$a\' {} \; | awk '{print "  " $0 " \\"}' >> $WORKSPACE/.install-dependencies.sh ; \
     elif [[ -f src/target/${ADDITIONAL_PIP_FILE} ]]; then \
-        cat src/target/${ADDITIONAL_PIP_FILE} | awk '!/^#/ {print "  " $0 " \\"}' >> $WORKSPACE/.install-dependencies.sh ; \
+        cat src/target/${ADDITIONAL_PIP_FILE} | awk '{ gsub(/#.*/, ""); gsub(/^[ \t]+|[ \t]+$/, ""); if (NF) print "  " $0 " \\" }' >> $WORKSPACE/.install-dependencies.sh ; \
     fi && \
     echo ";" >> $WORKSPACE/.install-dependencies.sh
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -88,7 +88,7 @@ RUN echo "colcon list -p --base-paths src/ --packages-select \\" >> $WORKSPACE/.
     if [[ $ENABLE_RECURSIVE_BLACKLISTED_PACKAGES == 'true' ]]; then \
         find . -type f -name $(basename ${BLACKLISTED_PACKAGES_FILE}) -exec sed '$a\' {} \; | awk '{print "  " $0 " \\"}' >> $WORKSPACE/.remove-packages.sh ; \
     elif [[ -f src/target/${BLACKLISTED_PACKAGES_FILE} ]]; then \
-        cat src/target/${BLACKLISTED_PACKAGES_FILE} | awk '{print "  " $0 " \\"}' >> $WORKSPACE/.remove-packages.sh ; \
+        cat src/target/${BLACKLISTED_PACKAGES_FILE} | awk '!/^#/ {print "  " $0 " \\"}' >> $WORKSPACE/.remove-packages.sh ; \
     fi && \
     echo ";" >> $WORKSPACE/.remove-packages.sh && \
     chmod +x $WORKSPACE/.remove-packages.sh && \
@@ -129,7 +129,7 @@ RUN echo "apt-get install -y \\" >> $WORKSPACE/.install-dependencies.sh && \
     if [[ $ENABLE_RECURSIVE_ADDITIONAL_DEBS == 'true' ]]; then \
         find . -type f -name $(basename ${ADDITIONAL_DEBS_FILE}) -exec sed '$a\' {} \; | awk '{print "  " $0 " \\"}' >> $WORKSPACE/.install-dependencies.sh ; \
     elif [[ -f src/target/${ADDITIONAL_DEBS_FILE} ]]; then \
-        cat src/target/${ADDITIONAL_DEBS_FILE} | awk '{print "  " $0 " \\"}' >> $WORKSPACE/.install-dependencies.sh ; \
+        cat src/target/${ADDITIONAL_DEBS_FILE} | awk '!/^#/ {print "  " $0 " \\"}' >> $WORKSPACE/.install-dependencies.sh ; \
     fi && \
     echo ";" >> $WORKSPACE/.install-dependencies.sh
 
@@ -141,7 +141,7 @@ RUN echo "pip install pip \\" >> $WORKSPACE/.install-dependencies.sh && \
     if [[ $ENABLE_RECURSIVE_ADDITIONAL_PIP == 'true' ]]; then \
         find . -type f -name $(basename ${ADDITIONAL_PIP_FILE}) -exec sed '$a\' {} \; | awk '{print "  " $0 " \\"}' >> $WORKSPACE/.install-dependencies.sh ; \
     elif [[ -f src/target/${ADDITIONAL_PIP_FILE} ]]; then \
-        cat src/target/${ADDITIONAL_PIP_FILE} | awk '{print "  " $0 " \\"}' >> $WORKSPACE/.install-dependencies.sh ; \
+        cat src/target/${ADDITIONAL_PIP_FILE} | awk '!/^#/ {print "  " $0 " \\"}' >> $WORKSPACE/.install-dependencies.sh ; \
     fi && \
     echo ";" >> $WORKSPACE/.install-dependencies.sh
 


### PR DESCRIPTION
When installing the additional pip and deb requirements, adding a comment line is really useful for us. But current script throws an error when doing so and considers the commented line as a package. 