### PR TITLE
Add possibility to enable OpenSSH Server

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -271,6 +271,16 @@ ENTRYPOINT ["/tini", "--", "/entrypoint.sh"]
 ############ dev ###############################################################
 FROM dependencies-install AS dev
 
+# Optionally install and configure SSH server on custom port (to account for net=host)
+ARG ENABLE_SSH=false
+ARG ENABLE_SSH_PORT=2222
+RUN if [ "${ENABLE_SSH}" = "true" ]; then \
+    apt-get update && \
+    apt-get install -y openssh-server && \
+    rm -rf /var/lib/apt/lists/* && \
+    sed -i 's/#Port 22/Port ${ENABLE_SSH_PORT}/' /etc/ssh/sshd_config; \ 
+    fi
+
 # copy contents of repository from dependencies stage
 COPY --from=dependencies $WORKSPACE/src $WORKSPACE/src
 
@@ -295,6 +305,15 @@ FROM dependencies-install AS run
 
 # remove source code, if still existing from custom.sh modifications
 RUN rm -rf $WORKSPACE/src
+
+# Optionally install and configure SSH server on port 2222
+ARG ENABLE_SSH=false
+RUN if [ "${ENABLE_SSH}" = "true" ]; then \
+    apt-get update && \
+    apt-get install -y openssh-server && \
+    rm -rf /var/lib/apt/lists/* && \
+    sed -i 's/#Port 22/Port 2222/' /etc/ssh/sshd_config; \ 
+    fi
 
 # copy ROS install space from build stage
 COPY --from=build $WORKSPACE/install install


### PR DESCRIPTION
With this change it is possible to directly ssh into the container.
This adds the following variables:
- ENABLE_SSH (default `false`)
- ENABLE_SSH_PORT (default `2222`)