### PR TITLE
Remove slim artifacts to fix caching in GitHub CI

### DIFF
--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -87,21 +87,19 @@ for PLATFORM in "${PLATFORMS[@]}"; do
     done
 
     # slim image
-    if [[ "${ENABLE_SLIM}" == "true" && "${TARGET}" == "run" ]]; then
+    if [[ "${ENABLE_SLIM}" == "true" && "${TARGET}" == "run" && ${_ENABLE_IMAGE_PUSH} == "true" ]]; then
         open_log_group "Slim image (${PLATFORM})"
         image="${IMAGE}"
         slim_image="${SLIM_IMAGE}"
         [[ -n "${_IMAGE_POSTFIX}" ]] && image="${image}${_IMAGE_POSTFIX}"
         [[ -n "${_IMAGE_POSTFIX}" ]] && slim_image="${slim_image}${_IMAGE_POSTFIX}"
-        [[ "${_ENABLE_IMAGE_PUSH}" != "true" || "${ENABLE_SINGLEARCH_PUSH}" == "true" ]] && image="${image}-${PLATFORM}"
-        [[ "${_ENABLE_IMAGE_PUSH}" != "true" || "${ENABLE_SINGLEARCH_PUSH}" == "true" ]] && slim_image="${slim_image}-${PLATFORM}"
+        [[ "${ENABLE_SINGLEARCH_PUSH}" == "true" ]] && image="${image}-${PLATFORM}"
+        [[ "${ENABLE_SINGLEARCH_PUSH}" == "true" ]] && slim_image="${slim_image}-${PLATFORM}"
         curl -L -o ds.tar.gz https://github.com/slimtoolkit/slim/releases/download/1.40.11/dist_linux.tar.gz
         tar -xvf ds.tar.gz
         cd dist_linux*
         ./slim build --target "${image}" --tag "${slim_image}" ${SLIM_BUILD_ARGS}
-        if [[ "${_ENABLE_IMAGE_PUSH}" == "true" ]]; then
-            docker push "${slim_image}"
-        fi
+        docker push "${slim_image}"
         cd -
         rm -rf dist_linux* ds.tar.gz
         close_log_group


### PR DESCRIPTION
The previous integration of slim invalidated the docker build cache between subsequent builds (one build with --load and one build with --push is default for every GitHub CI).