### PR TITLE
Push :TAG also without explicit ENABLE_PUSH_AS_LATEST

### DIFF
--- a/.gitlab-ci/docker-ros.yml
+++ b/.gitlab-ci/docker-ros.yml
@@ -421,7 +421,7 @@ Push tag:
   extends: .push
   rules:
     - !reference [.push, rules]
-    - if: $CI_COMMIT_TAG && $ENABLE_PUSH_AS_LATEST == 'true'
+    - if: $CI_COMMIT_TAG && ($ENABLE_PUSH_AS_LATEST == 'true' || $IMAGE_TAG == 'latest')
   variables:
     IMG_DEV: ${_IMAGE_DEV_TAG}
     IMG_RUN: ${_IMAGE_RUN_TAG}


### PR DESCRIPTION
Previously, if a simple GitLab CI was set up, a GitLab tag would trigger to push an image tag "latest-<TAG>". Only if ENABLE_PUSH_AS_LATEST was enabled, would it trigger an image tag "<TAG>".

Now this tag will always be created. If there is need for ENABLE_PUSH_AS_LATEST, because there are multiple CIs for the same project with different IMAGE_TAG, then still only the one with ENABLE_PUSH_AS_LATEST will push that tag.

Note that this change only influences GitLab CI, as (apparently?) GitHub CI doesn't produce special Git-tagged images anyway.