### PR TITLE
Allow version requirements in `additional-pip-requirements.txt`

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -137,9 +137,9 @@ ARG ENABLE_RECURSIVE_ADDITIONAL_PIP="false"
 RUN echo "pip install pip \\" >> $WORKSPACE/.install-dependencies.sh && \
     set -o pipefail && \
     if [[ $ENABLE_RECURSIVE_ADDITIONAL_PIP == 'true' ]]; then \
-        find . -type f -name $(basename ${ADDITIONAL_PIP_FILE}) -exec sed "$ a\\" {} \; | awk '{print "  " $0 " \\"}' >> $WORKSPACE/.install-dependencies.sh ; \
+        find . -type f -name $(basename ${ADDITIONAL_PIP_FILE}) -exec sed "$ a\\" {} \; | awk '{print "  \"" $0 "\" \\"}' >> $WORKSPACE/.install-dependencies.sh ; \
     elif [[ -f src/target/${ADDITIONAL_PIP_FILE} ]]; then \
-        cat src/target/${ADDITIONAL_PIP_FILE} | awk '{ gsub(/#.*/, ""); gsub(/^[ \t]+|[ \t]+$/, ""); if (NF) print "  " $0 " \\" }' >> $WORKSPACE/.install-dependencies.sh ; \
+        cat src/target/${ADDITIONAL_PIP_FILE} | awk '{ gsub(/#.*/, ""); gsub(/^[ \t]+|[ \t]+$/, ""); if (NF) print "  \"" $0 "\" \\" }' >> $WORKSPACE/.install-dependencies.sh ; \
     fi && \
     echo ";" >> $WORKSPACE/.install-dependencies.sh
 


### PR DESCRIPTION
It may be necessary to set version requirements for pip packages to be installed via `additional-pip-requirements.txt`, e.g.:

```
scipy>=1.15.0
```

## Current Behavior

This is currently not supported because `>` is interpreted as piping operator resulting in a file called `=1.15.0` created in `/docker-ros/ws` instead of installing the package.

```
  #32 [dependencies 21/22] RUN cat /docker-ros/ws/.install-dependencies.sh
  #32 0.038 apt-get install -y \
  #32 0.038 ;
  #32 0.038 pip install pip \
  #32 0.038   scipy>=1.15.0 \
  #32 0.038 ;
  #32 DONE 0.0s
```

## Updated Behavior

This PR ensures that all package names are put in quotes when added to `.install-dependencies.sh`, e.g.:

```
  #32 [dependencies 21/22] RUN cat /docker-ros/ws/.install-dependencies.sh
  #32 0.054 pip install pip \
  #32 0.054   "scipy>=1.15.0" \
  #32 0.054 ;
  #32 DONE 0.1s
```