### PR TITLE
Make entrypoint in dev images enforce execution of `bash` in interactive and `sleep infinity` in non-interactive shells

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -257,7 +257,6 @@ ENV TINI_VERSION=v0.19.0
 ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-${TARGETARCH} /tini
 RUN chmod +x /tini
 COPY docker/docker-ros/docker/entrypoint.sh /
-ENTRYPOINT ["/tini", "--", "/entrypoint.sh"]
 
 ############ dev ###############################################################
 FROM dependencies-install AS dev
@@ -265,6 +264,7 @@ FROM dependencies-install AS dev
 # copy contents of repository from dependencies stage
 COPY --from=dependencies $WORKSPACE/src $WORKSPACE/src
 
+ENTRYPOINT ["/tini", "--", "/entrypoint.sh", "dev"]
 CMD ["bash"]
 
 ############ build #############################################################
@@ -287,6 +287,7 @@ COPY --from=build $WORKSPACE/install install
 RUN ldconfig
 
 # setup command
+ENTRYPOINT ["/tini", "--", "/entrypoint.sh", "run"]
 ARG COMMAND
 ENV DEFAULT_CMD=${COMMAND}
 CMD bash -c "${DEFAULT_CMD}"

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 set -e
 
+first_arg="$1"  # 'dev' or 'run' image
+remaining_args=("${@:2}")  # command
+
 # source ROS workspace
 source /opt/ros/$ROS_DISTRO/setup.bash
 [[ -f /opt/ws_base_image/install/setup.bash ]] && source /opt/ws_base_image/install/setup.bash
@@ -33,7 +36,21 @@ if [[ $DOCKER_UID && $DOCKER_GID ]]; then
         echo -e "\e[33mWARNING | Cannot create user '$DOCKER_USER' with UID $DOCKER_UID, another user '$(getent passwd $DOCKER_UID | cut -d: -f1)' with same UID is already existing\e[0m"
     fi
     [[ $(pwd) == "$WORKSPACE" ]] && cd /home/$DOCKER_USER/ws
-    exec gosu $DOCKER_USER "$@"
+    if [[ "$first_arg" == "dev" ]]; then
+        exec gosu $DOCKER_USER bash
+    elif [[ "$first_arg" == "run" ]]; then
+        exec gosu $DOCKER_USER "$remaining_args"
+    else
+        echo "ERROR: first_arg must be 'dev' or 'run', got '$first_arg'" >&2
+        exit 1
+    fi
 else
-    exec "$@"
+    if [[ "$first_arg" == "dev" ]]; then
+        exec bash
+    elif [[ "$first_arg" == "run" ]]; then
+        exec "$remaining_args"
+    else
+        echo "ERROR: first_arg must be 'dev' or 'run', got '$first_arg'" >&2
+        exit 1
+    fi
 fi

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -46,7 +46,7 @@ if [[ $DOCKER_UID && $DOCKER_GID ]]; then
     elif [[ "$docker_build_stage" == "run" ]]; then
         exec gosu $DOCKER_USER "${command[@]}"
     else
-        echo "ERROR: docker_build_stage must be 'dev' or 'run', got '$docker_build_stage'" >&2
+        echo -e "\e[33mERROR | docker_build_stage must be 'dev' or 'run', got '$docker_build_stage'\e[0m"
         exit 1
     fi
 else

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -37,7 +37,11 @@ if [[ $DOCKER_UID && $DOCKER_GID ]]; then
     fi
     [[ $(pwd) == "$WORKSPACE" ]] && cd /home/$DOCKER_USER/ws
     if [[ "$first_arg" == "dev" ]]; then
-        exec gosu $DOCKER_USER bash
+        if [ -t 0 ] ; then
+            exec gosu $DOCKER_USER bash
+        else
+            exec gosu $DOCKER_USER sleep infinity
+        fi
     elif [[ "$first_arg" == "run" ]]; then
         exec gosu $DOCKER_USER "${remaining_args[@]}"
     else
@@ -46,7 +50,11 @@ if [[ $DOCKER_UID && $DOCKER_GID ]]; then
     fi
 else
     if [[ "$first_arg" == "dev" ]]; then
-        exec bash
+        if [ -t 0 ] ; then
+            exec bash
+        else
+            exec sleep infinity
+        fi
     elif [[ "$first_arg" == "run" ]]; then
         exec "${remaining_args[@]}"
     else

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -39,7 +39,7 @@ if [[ $DOCKER_UID && $DOCKER_GID ]]; then
     if [[ "$first_arg" == "dev" ]]; then
         exec gosu $DOCKER_USER bash
     elif [[ "$first_arg" == "run" ]]; then
-        exec gosu $DOCKER_USER "$remaining_args"
+        exec gosu $DOCKER_USER "${remaining_args[@]}"
     else
         echo "ERROR: first_arg must be 'dev' or 'run', got '$first_arg'" >&2
         exit 1
@@ -48,7 +48,7 @@ else
     if [[ "$first_arg" == "dev" ]]; then
         exec bash
     elif [[ "$first_arg" == "run" ]]; then
-        exec "$remaining_args"
+        exec "${remaining_args[@]}"
     else
         echo "ERROR: first_arg must be 'dev' or 'run', got '$first_arg'" >&2
         exit 1

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 set -e
 
-first_arg="$1"  # 'dev' or 'run' image
-remaining_args=("${@:2}")  # command
+docker_build_stage="$1"  # 'dev' or 'run' stage
+command=("${@:2}")  # command
 
 # source ROS workspace
 source /opt/ros/$ROS_DISTRO/setup.bash
@@ -36,29 +36,31 @@ if [[ $DOCKER_UID && $DOCKER_GID ]]; then
         echo -e "\e[33mWARNING | Cannot create user '$DOCKER_USER' with UID $DOCKER_UID, another user '$(getent passwd $DOCKER_UID | cut -d: -f1)' with same UID is already existing\e[0m"
     fi
     [[ $(pwd) == "$WORKSPACE" ]] && cd /home/$DOCKER_USER/ws
-    if [[ "$first_arg" == "dev" ]]; then
+    if [[ "$docker_build_stage" == "dev" ]]; then
         if [ -t 0 ] ; then
             exec gosu $DOCKER_USER bash
         else
+            echo "Keeping non-interactive dev container running. Attach to the container with 'docker exec -it ...'."
             exec gosu $DOCKER_USER sleep infinity
         fi
-    elif [[ "$first_arg" == "run" ]]; then
-        exec gosu $DOCKER_USER "${remaining_args[@]}"
+    elif [[ "$docker_build_stage" == "run" ]]; then
+        exec gosu $DOCKER_USER "${command[@]}"
     else
-        echo "ERROR: first_arg must be 'dev' or 'run', got '$first_arg'" >&2
+        echo "ERROR: docker_build_stage must be 'dev' or 'run', got '$docker_build_stage'" >&2
         exit 1
     fi
 else
-    if [[ "$first_arg" == "dev" ]]; then
+    if [[ "$docker_build_stage" == "dev" ]]; then
         if [ -t 0 ] ; then
             exec bash
         else
+            echo "Keeping non-interactive dev container running. Attach to the container with 'docker exec -it ...'."
             exec sleep infinity
         fi
-    elif [[ "$first_arg" == "run" ]]; then
-        exec "${remaining_args[@]}"
+    elif [[ "$docker_build_stage" == "run" ]]; then
+        exec "${command[@]}"
     else
-        echo "ERROR: first_arg must be 'dev' or 'run', got '$first_arg'" >&2
+        echo -e "\e[33mERROR | docker_build_stage must be 'dev' or 'run', got '$docker_build_stage'\e[0m"
         exit 1
     fi
 fi


### PR DESCRIPTION
This PR creates different entrypoints in `dev` and `run` images.

In **`dev` images**, the container will open a `bash` if an interactive shell is available in the container, e.g. if the container was launched with `docker run -it ...` or it will execute `sleep infinity` if launched with a non-interactive shell, e.g. as service in a docker compose setup. 
Additionally, the `<COMMAND>` passed to `docker run -it <IMAGE> <COMMAND>` or in a compose `service.command` will be ignored. Thus, it is not required to overwrite the `service.command` with `sleep infinity` anymore when switching from a `run` to a `dev` image for development.

The **`run` images** have the same behavior as before.

The feature can be tested with [this docker compose file](https://github.com/openads-project/openads_ros2_demo_repository/blob/dev-entrypoint/docker-compose.yml) using the images built in [this docker-ros pipeline](https://github.com/openads-project/openads_ros2_demo_repository/actions/runs/24384280323/job/71214360766).