### PR TITLE
Dev Image: Add devcontainer config as LABEL and make default command available via script

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -263,6 +263,8 @@ ENTRYPOINT ["/tini", "--", "/entrypoint.sh"]
 FROM dependencies-install AS dev
 
 # configure VS Code devcontainer
+# Reference: https://containers.dev/implementors/json_reference/
+# Aligned with: https://github.com/openads-project/openads-dev-environment/blob/main/.devcontainer/devcontainer.json
 LABEL devcontainer.metadata='[{ \
   "capAdd": [ "SYS_PTRACE" ], \
   "containerEnv": { \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -262,6 +262,34 @@ ENTRYPOINT ["/tini", "--", "/entrypoint.sh"]
 ############ dev ###############################################################
 FROM dependencies-install AS dev
 
+# configure VS Code devcontainer
+LABEL devcontainer.metadata='[{ \
+  "capAdd": [ "SYS_PTRACE" ], \
+  "containerEnv": { \
+    "PIP_BREAK_SYSTEM_PACKAGES": "1" \
+    }, \
+  "customizations": { \
+    "vscode": { \
+      "settings": { \
+        "ROS2.rosSetupScript": "/docker-ros/ws/install/setup.bash" \
+      }, \
+      "extensions": [ \
+        "althack.ament-task-provider", \
+        "cschlosser.doxdocgen", \
+        "mhutchie.git-graph", \
+        "ms-python.black-formatter", \
+        "ms-python.flake8", \
+        "ms-python.python", \
+        "ms-vscode.cpp-devtools", \
+        "ms-vscode.cpptools-themes", \
+        "ms-vscode.cpptools", \
+        "njpwerner.autodocstring", \
+        "Ranch-Hand-Robotics.rde-pack" \
+      ] \
+    } \
+  } \
+}]'
+
 # copy contents of repository from dependencies stage
 COPY --from=dependencies $WORKSPACE/src $WORKSPACE/src
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -296,7 +296,9 @@ COPY --from=dependencies $WORKSPACE/src $WORKSPACE/src
 # write default command into script
 ARG COMMAND
 ENV DEFAULT_CMD=${COMMAND}
-RUN echo "${DEFAULT_CMD}" > /usr/local/bin/run_default_command && chmod +x /usr/local/bin/run_default_command
+RUN echo "source ${WORKSPACE}/install/setup.bash" > /usr/local/bin/run_default_command && \
+    echo "${DEFAULT_CMD}" >> /usr/local/bin/run_default_command && \
+    chmod +x /usr/local/bin/run_default_command
 
 CMD ["bash"]
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -293,6 +293,11 @@ LABEL devcontainer.metadata='[{ \
 # copy contents of repository from dependencies stage
 COPY --from=dependencies $WORKSPACE/src $WORKSPACE/src
 
+# write default command into script
+ARG COMMAND
+ENV DEFAULT_CMD=${COMMAND}
+RUN echo "${DEFAULT_CMD}" > /usr/local/bin/run_default_command && chmod +x /usr/local/bin/run_default_command
+
 CMD ["bash"]
 
 ############ build #############################################################


### PR DESCRIPTION
Sets `LABEL devcontainer.metadata` in dev images built by `docker-ros` that are also effective when attaching VS Code to a running container, e.g. started in a compose setup. Note that [not all devcontainer configuration options are supported](https://containers.dev/implementors/json_reference/), e.g. setting the `workspaceFolder`. Closes #80.

Make the default command (configured via docker-ros CI variable) available in dev images via `DEFAULT_COMMAND` environment variable and via `run_default_command` script. This is only useful if the configured default command is actually used also in compositions and not overridden in the docker compose file. Hence, we should also set launch arguments to environment variables (with fallbacks to default values) in the configured default command. Closes #81.