### PR TITLE
Fix creation of tag images (e.g. `:vX.Y.Z`) in GitHub CI

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -332,7 +332,7 @@ runs:
         GIT_SSH_KNOWN_HOST_KEYS: ${{ inputs.git-ssh-known-host-keys }}
         GIT_SSH_PRIVATE_KEY: ${{ inputs.git-ssh-private-key }}
         IMAGE_NAME: ${{ steps.image-name.outputs.lowercase }}
-        IMAGE_TAG: ${{ inputs.image-tag }}
+        IMAGE_TAG: ${{ github.ref_type == 'tag' && (inputs.image-tag != 'latest' && format('{0}-{1}', inputs.image-tag, github.ref_name) || github.ref_name) || inputs.image-tag }}
         LABEL_AUTHORS: ${{ inputs.label-authors }}
         LABEL_DESCRIPTION: ${{ inputs.label-description }}
         LABEL_LICENSES: ${{ inputs.label-licenses }}
@@ -348,7 +348,7 @@ runs:
         TARGET: ${{ inputs.target }}
         VCS_IMPORT_FILE: ${{ inputs.vcs-import-file }}
         _ENABLE_IMAGE_PUSH: true
-        _IMAGE_POSTFIX: ${{ github.ref != format('refs/heads/{0}', github.event.repository.default_branch) && format('_{0}_ci', steps.slugify-ref-name.outputs.slug) || '' }}
+        _IMAGE_POSTFIX: ${{ github.ref_type != 'tag' && github.ref != format('refs/heads/{0}', github.event.repository.default_branch) && format('_{0}_ci', steps.slugify-ref-name.outputs.slug) || '' }}
 
     - name: Push images (as latest)
       if: ${{ inputs.enable-push-as-latest == 'true' }}
@@ -385,7 +385,7 @@ runs:
         GIT_SSH_KNOWN_HOST_KEYS: ${{ inputs.git-ssh-known-host-keys }}
         GIT_SSH_PRIVATE_KEY: ${{ inputs.git-ssh-private-key }}
         IMAGE_NAME: ${{ steps.image-name.outputs.lowercase }}
-        IMAGE_TAG: latest
+        IMAGE_TAG: ${{ github.ref_type == 'tag' && github.ref_name || 'latest' }}
         LABEL_AUTHORS: ${{ inputs.label-authors }}
         LABEL_DESCRIPTION: ${{ inputs.label-description }}
         LABEL_LICENSES: ${{ inputs.label-licenses }}
@@ -401,4 +401,4 @@ runs:
         TARGET: ${{ inputs.target }}
         VCS_IMPORT_FILE: ${{ inputs.vcs-import-file }}
         _ENABLE_IMAGE_PUSH: true
-        _IMAGE_POSTFIX: ${{ github.ref != format('refs/heads/{0}', github.event.repository.default_branch) && format('_{0}_ci', steps.slugify-ref-name.outputs.slug) || '' }}
+        _IMAGE_POSTFIX: ${{ github.ref_type != 'tag' && github.ref != format('refs/heads/{0}', github.event.repository.default_branch) && format('_{0}_ci', steps.slugify-ref-name.outputs.slug) || '' }}

--- a/action.yml
+++ b/action.yml
@@ -369,7 +369,7 @@ runs:
         COMMAND: ${{ inputs.command }}
         CMAKE_ARGS: ${{ inputs.cmake-args }}
         DEV_IMAGE_NAME: ${{ steps.dev-image-name.outputs.lowercase }}
-        DEV_IMAGE_TAG: latest-dev
+        DEV_IMAGE_TAG: ${{ github.ref_type == 'tag' && github.ref_name || 'latest' }}-dev
         DISABLE_ROS_INSTALLATION: ${{ inputs.disable-ros-installation }}
         ENABLE_RECURSIVE_ADDITIONAL_DEBS: ${{ inputs.enable-recursive-additional-debs }}
         ENABLE_RECURSIVE_ADDITIONAL_PIP: ${{ inputs.enable-recursive-additional-pip }}
@@ -397,7 +397,7 @@ runs:
         ROS_DISTRO: ${{ inputs.ros-distro }}
         SLIM_BUILD_ARGS: ${{ inputs.slim-build-args }}
         SLIM_IMAGE_NAME: ${{ steps.slim-image-name.outputs.lowercase }}
-        SLIM_IMAGE_TAG: latest-slim
+        SLIM_IMAGE_TAG: ${{ github.ref_type == 'tag' && github.ref_name || 'latest' }}-slim
         TARGET: ${{ inputs.target }}
         VCS_IMPORT_FILE: ${{ inputs.vcs-import-file }}
         _ENABLE_IMAGE_PUSH: true


### PR DESCRIPTION
Container image tags for Git tag pipelines (e.g., `ghcr.io/openads-project/trajectory_optimization:v1.3.0`) are currently not being created correctly on GitHub CI. Note that this issue only refers to GitHub CI, not GitLab CI, where everything seems to be working as expected.

The issue was noticed here:
- [ika-rwth-aachen/image_reprojection @ v1.1.0](https://github.com/ika-rwth-aachen/image_reprojection/actions/runs/27192249883)  
  tag pipeline incorrectly pushed `ghcr.io/ika-rwth-aachen/image_reprojection:latest_v1-1-0_ci`
- [openads-project/trajectory_optimization @ v1.2.0](https://github.com/openads-project/trajectory_optimization/actions/workflows/docker-ros.yml)  
  tag pipeline did not run at all, because [docker-ros CI is not configured to run on tags](https://github.com/openads-project/trajectory_optimization/blob/main/.github/workflows/docker-ros.yml)

### Previous Incorrect Behavior

| Pipeline | image-tag | enable-push-as-latest |  | Push images | Push images (as latest) |
|---|---|---:|---|---|---|
| default branch `main` | `latest` | `false` |  | `latest` | - |
| other branch `other_branch` | `latest` | `false` |  | `latest_other-branch_ci` | - |
| tag `v1.2.3` | `latest` | `false` |  | `latest_v1-2-3_ci` | - |
| default branch `main` | `jazzy` | `true` |  | `jazzy` | `latest` |
| other branch `other_branch` | `jazzy` | `true` |  | `jazzy_other-branch_ci` | `latest_other-branch_ci` |
| tag `v1.2.3` | `jazzy` | `true` |  | `jazzy_v1-2-3_ci` | `latest_v1-2-3_ci` |
| tag `v1.2.3` | `humble` | `false` |  | `humble_v1-2-3_ci` | - |
| default branch `main` | `humble` | `false` |  | `humble` | - |
| other branch `other_branch` | `humble` | `false` |  | `humble_other-branch_ci` | - |

Assuming `enable-singlearch-push: false`.

### New Fixed Behavior

| Pipeline | image-tag | enable-push-as-latest |  | Push images | Push images (as latest) |
|---|---|---:|---|---|---|
| default branch `main` | `latest` | `false` |  | `latest` | - |
| other branch `other_branch` | `latest` | `false` |  | `latest_other-branch_ci` | - |
| tag `v1.2.3` | `latest` | `false` |  | `v1.2.3` | - |
| default branch `main` | `jazzy` | `true` |  | `jazzy` | `latest` |
| other branch `other_branch` | `jazzy` | `true` |  | `jazzy_other-branch_ci` | `latest_other-branch_ci` |
| tag `v1.2.3` | `jazzy` | `true` |  | `jazzy-v1.2.3` | `v1.2.3` |
| tag `v1.2.3` | `humble` | `false` |  | `humble-v1.2.3` | - |
| default branch `main` | `humble` | `false` |  | `humble` | - |
| other branch `other_branch` | `humble` | `false` |  | `humble_other-branch_ci` | - |

Assuming `enable-singlearch-push: false`.
