### PR TITLE
Ensure action inputs are aligned with readme

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -90,7 +90,9 @@ inputs:
     default: false
   enable-recursive-blacklisted-packages:
     description: "Enable recursive discovery of files named `blacklisted-packages-file`"
-    default: false
+  enable-recursive-vcs-import:
+    description: "Enable recursive discovery of files named `*.repos`"
+    default: "true"
   enable-singlearch-push:
     description: "Enable push of single arch images with [-amd64|-arm64] postfix"
     default: false
@@ -174,6 +176,9 @@ inputs:
   target:
     description: "Target stage of Dockerfile (comma-separated list) [dev|run]"
     default: run
+  vcs-import-file:
+    description: "Relative filepath to file containing additional repos to install via vcstools (only relevant if enable-recursive-vcs-import=false)"
+    default: .repos
 
 
 runs:

--- a/action.yml
+++ b/action.yml
@@ -47,7 +47,7 @@ inputs:
     default: ${{ github.workspace }}
   buildx-attestations:
     description: "Value passed to `docker buildx build --provenance` and `--sbom` (use `false` for older registries)"
-    default: false
+    default: "false"
   command:
     description: "Launch command of run image (required if target=run)"
   cmake-args:
@@ -60,45 +60,46 @@ inputs:
     description: "Image tag of dev image"
   disable-ros-installation:
     description: "Disable automatic installation of `ros-$ROS_DISTRO-ros-core` package, e.g., if ROS is already installed in `base-image` and package is not available for the OS"
-    default: false
+    default: "false"
   enable-checkout:
     description: "Enable checkout action to (re-)download your repository prior to running the pipeline"
-    default: true
+    default: "true"
   enable-checkout-lfs:
     description: "Enable Git LFS support for the checkout action"
-    default: true
+    default: "true"
   enable-checkout-submodules:
     description: "Enable submodules for the checkout action (false|true|recursive)"
     default: recursive
   enable-industrial-ci:
     description: "Enable industrial_ci"
-    default: false
+    default: "false"
   enable-push-as-latest:
     description: "Push images with tag `latest`/`latest-dev` in addition to the configured image names"
-    default: false
+    default: "false"
   enable-recursive-additional-debs:
     description: "Enable recursive discovery of files named `additional-debs-file`"
-    default: false
+    default: "false"
   enable-recursive-additional-pip:
     description: "Enable recursive discovery of files named `additional-pip-file`"
-    default: false
+    default: "false"
   enable-recursive-after-dependency-installation-script:
     description: "Enable recursive discovery of files named `after-dependency-installation-script`"
-    default: false
+    default: "false"
   enable-recursive-before-dependency-installation-script:
     description: "Enable recursive discovery of files named `before-dependency-installation-script`"
-    default: false
+    default: "false"
   enable-recursive-blacklisted-packages:
     description: "Enable recursive discovery of files named `blacklisted-packages-file`"
+    default: "false"
   enable-recursive-vcs-import:
     description: "Enable recursive discovery of files named `*.repos`"
     default: "true"
   enable-singlearch-push:
     description: "Enable push of single arch images with [-amd64|-arm64] postfix"
-    default: false
+    default: "false"
   enable-slim:
     description: "Enable an extra slimmed run image via mint (only if run stage is targeted)"
-    default: true
+    default: "true"
   git-https-password:
     description: "Password for cloning private Git repositories via HTTPS"
     default: ${{ github.token }}


### PR DESCRIPTION
The following inputs of the `docker-ros` action were listed in the README but not configured in `action.yml`
- `enable-recursive-vcs-import`
- `vcs-import-file`

<img width="568" height="195" alt="image" src="https://github.com/user-attachments/assets/47920aad-b69f-4135-bb6e-bc8d75bb8759" />

They were added with this PR.

Additionally, the [GitHub Action scheme](https://www.schemastore.org/github-action.json) requires [input defaults to be strings](https://docs.github.com/en/actions/reference/workflows-and-actions/metadata-syntax#inputsinput_iddefault). Hence all booleans were converted to strings.